### PR TITLE
Noise calculation is now calculated and sent out as part of entry to xdripAPS and Nightscout

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ sudo apt-get install nodejs -y
 ```
 
 ## Installation
+​
+61
+```
+62
+​
+63
 ```
 cd ~/src
 git clone https://github.com/efidoman/xdrip-js-logger.git
@@ -55,15 +61,6 @@ sudo apt-get install bluez-tools
 Add cron job entry (replace "40SNU6" with your g5 transmitter id in both places below) ...
 ```
 * * * * * cd /root/src/xdrip-js-logger && ps aux | grep -v grep | grep -q '40SNU6' || ./xdrip-get-entries.sh 40SNU6 | tee -a /var/log/openaps/xdrip-js-loop.log
-```
-
-## Logger usage - running stand-alone
-
-You can also run
-```
-cd /root/src/xdrip-js-logger
-./xdrip-get-entries 40SNU6
-# replace 40SNU6 with your transmitter id
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ sudo apt-get install nodejs -y
 ```
 
 ## Installation
-​
-61
-```
-62
-​
-63
 ```
 cd ~/src
 git clone https://github.com/efidoman/xdrip-js-logger.git

--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 # xdrip-js-logger - the xdrip-js One-Shot Mode Logger.
 
-Logger connects to the g5 transmitter, waits for the first bg, logs a json entry record, then exits. Doing it one-shot at a time seems to make xdrip-js more reliable in some cases. xdrip-get-entries.sh is a wrapper shell script that is called from cron every minute. It calls the one shot mode logger handling the preparation and sending of the blood glucose data to Nightscout and to OpenAPS.
+Logger connects to the g5 transmitter, waits for the first bg, logs a json entry record, then exits. Doing it one-shot at a time seems to make xdrip-js more reliable in some cases. xdrip-get-entries.sh is a wrapper shell script that is called from cron every minute. Current xdrip-js-logger (Logger) features:
+
+* Preparation and sending of the blood glucose data to Nightscout and to OpenAPS.
+* Offline mode - Logger runs on the rig and sends bg data directly to openaps through via xdripAPS. Logger queues up NS updates while internet is down and fills in the gaps when internet is restored.
+* Calibration via linear least squares regression (LSR) (similar to xdrip plus)
+  * Calibrations must be input into Nightscout as BG Check treatments.
+  * Logger will not calculate or send any BG data out unless at least one  calibration has been done in Nightscout.
+  * LSR calibration only comes into play after 3 or more calibrations. When there one or two calibrations, single point linear calibration is used.
+  * The calibration cache will be cleared for the first 15 minutes after a Nightscout "CGM Sensor Insert" treatment has been posted.
+  * After 15 minutes, BG data will only be sent out after at least one calibration has been documented in Nightscout.
 
 # Warning! 
 
-Logger and xdrip-get-entries.sh currently use the raw g5 blood glucose data and a simple offset for calibration. Only those who closely monitor and check blood glucose regularly comparing to the raw ("unfiltered") g5 glucose data should use this program at this time.
+Logger LSR calibration is a new feature as of Feb/2018. Only those who closely monitor and check blood glucose and regularly review the Logger logfiles should use this program at this time.
+* /var/log/openaps/xdrip-js-loop.log
+* /var/log/openaps/g5.csv
+* /root/src/xdrip-js-logger/calibrations.csv - the current list of calibrations (unfiltered, BG check, datetime, BG Check ID)
+* /root/src/xdrip-js-logger/calibration-linear.json - the current calibration values (slope, yIntercept). Please note that other fields in this file are for informational purposes at this time. Unfiltered values from the g5 are on a 1,000 scale which explains why slope and yIntercept are 1,000 greater than glucose values.
+
 
 [![Join the chat at https://gitter.im/thebookins/xdrip-js](https://badges.gitter.im/thebookins/xdrip-js.svg)](https://gitter.im/thebookins/xdrip-js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -36,9 +50,6 @@ Add cron job entry (replace "40SNU6" with your g5 transmitter id in both places 
 ```
 
 ## Logger usage - running stand-alone
-`sudo node logger <######>` where `<######>` is the 6-character serial number of the transmitter.
-
-To see verbose output, use `sudo DEBUG=* node logger <######>`, or replace the `*` with a comma separated list of the modules you would like to debug. E.g. `sudo DEBUG=smp,transmitter,bluetooth-manager node logger <######>`.
 
 You can also run
 ```

--- a/README.md
+++ b/README.md
@@ -18,13 +18,21 @@ Logger LSR calibration is a new feature as of Feb/2018. Only those who closely m
 * /var/log/openaps/g5.csv
 * /root/src/xdrip-js-logger/calibrations.csv - the current list of calibrations (unfiltered, BG check, datetime, BG Check ID)
 * /root/src/xdrip-js-logger/calibration-linear.json - the current calibration values (slope, yIntercept). Please note that other fields in this file are for informational purposes at this time. Unfiltered values from the g5 are on a 1,000 scale which explains why slope and yIntercept are 1,000 greater than glucose values.
-
+\# where xxxx is your Nightscout url
 
 [![Join the chat at https://gitter.im/thebookins/xdrip-js](https://badges.gitter.im/thebookins/xdrip-js.svg)](https://gitter.im/thebookins/xdrip-js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 *Please note this project is neither created nor backed by Dexcom, Inc. This software is not intended for use in therapy.*
 ## Prerequisites
 Update node version. Follow these steps in this order.
+
+Set Nightscout environment variables in ~/.bash_profile. Make sure the following 4 lines are in this file. If not carefully add them paying close attention the values (xxxx is your hashed Nightscout API_SECRET and yyyy is your Nightscout URL):
+```
+API_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
+export API_SECRET
+NIGHTSCOUT_HOST=https://yyyy
+export NIGHTSCOUT_HOST
+```
 
 The version of Node that ships with jubilinux is old (v0.10.something). Here are the instructions for updating Node:
 ```
@@ -40,7 +48,7 @@ sudo apt-get install nodejs -y
 cd ~/src
 git clone https://github.com/efidoman/xdrip-js-logger.git
 cd xdrip-js-logger
-sudo npm run global-install
+sudo npm run global-install\# where xxxx is your Nightscout url
 sudo apt-get install bluez-tools
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,16 @@ Logger and xdrip-get-entries.sh currently use the raw g5 blood glucose data and 
 
 *Please note this project is neither created nor backed by Dexcom, Inc. This software is not intended for use in therapy.*
 ## Prerequisites
-Update node version. Please see wiki page for instructions https://github.com/thebookins/xdrip-js/wiki
+Update node version. Follow these steps in this order.
+
+The version of Node that ships with jubilinux is old (v0.10.something). Here are the instructions for updating Node:
+```
+sudo apt-get remove nodered -y
+sudo apt-get remove nodejs nodejs-legacy -y
+sudo apt-get remove npm  -y # if you installed npm
+sudo curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
+sudo apt-get install nodejs -y
+```
 
 ## Installation
 ```

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ git clone https://github.com/efidoman/xdrip-js-logger.git
 cd xdrip-js-logger
 sudo npm install
 sudo apt-get install bluez-tools
-cd ~/src/xdrip-js-logger
-chmod 755 xdrip-get-entries.sh post-ns.sh post-xdripAPS.sh
 ```
 
 Add cron job entry (replace "40SNU6" with your g5 transmitter id in both places below) ...

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sudo apt-get install nodejs -y
 cd ~/src
 git clone https://github.com/efidoman/xdrip-js-logger.git
 cd xdrip-js-logger
-sudo npm install
+sudo npm global-install
 sudo apt-get install bluez-tools
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sudo apt-get install nodejs -y
 cd ~/src
 git clone https://github.com/efidoman/xdrip-js-logger.git
 cd xdrip-js-logger
-sudo npm global-install
+sudo npm run global-install
 sudo apt-get install bluez-tools
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Logger LSR calibration is a new feature as of Feb/2018. Only those who closely m
 
 *Please note this project is neither created nor backed by Dexcom, Inc. This software is not intended for use in therapy.*
 ## Prerequisites
-Openaps must be installed using the CGM method of xdrip.
+* Openaps must be installed using the CGM method of xdrip.
+* Logger does not currently support token-based authentication with Nightscout
 
 Update node version. Follow these steps in this order.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Logger LSR calibration is a new feature as of Feb/2018. Only those who closely m
 * /var/log/openaps/g5.csv
 * /root/src/xdrip-js-logger/calibrations.csv - the current list of calibrations (unfiltered, BG check, datetime, BG Check ID)
 * /root/src/xdrip-js-logger/calibration-linear.json - the current calibration values (slope, yIntercept). Please note that other fields in this file are for informational purposes at this time. Unfiltered values from the g5 are on a 1,000 scale which explains why slope and yIntercept are 1,000 greater than glucose values.
-\# where xxxx is your Nightscout url
 
 [![Join the chat at https://gitter.im/thebookins/xdrip-js](https://badges.gitter.im/thebookins/xdrip-js.svg)](https://gitter.im/thebookins/xdrip-js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -48,7 +47,7 @@ sudo apt-get install nodejs -y
 cd ~/src
 git clone https://github.com/efidoman/xdrip-js-logger.git
 cd xdrip-js-logger
-sudo npm run global-install\# where xxxx is your Nightscout url
+sudo npm run global-install
 sudo apt-get install bluez-tools
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Logger LSR calibration is a new feature as of Feb/2018. Only those who closely m
 
 *Please note this project is neither created nor backed by Dexcom, Inc. This software is not intended for use in therapy.*
 ## Prerequisites
+Openaps must be installed using the CGM method of xdrip.
+
 Update node version. Follow these steps in this order.
 
 Set Nightscout environment variables in ~/.bash_profile. Make sure the following 4 lines are in this file. If not carefully add them paying close attention the values (xxxx is your hashed Nightscout API_SECRET and yyyy is your Nightscout URL):

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -202,6 +202,24 @@ elif [ $(bc <<< "$yIntercept < (0 - $maxIntercept)") -eq 1 ]; then
   echo "x=$x, y=$y, slope=$slope, yIntercept=0" 
 fi 
 
+
+# check slope again if SinglePoint for safety
+# this is for the case that we fell back to SinglePoint
+# to make sure that we don't have use without bounds a potentiall bad 
+# or mistaken calibration recent record
+if [ "$calibrationType" == "SinglePoint" ]; then
+  if [ $(bc <<< "$slope > $MAXSLOPE") -eq 1 ]; then
+    echo "single point slope of $slope > maxSlope of $MAXSLOPE, using $MAXSLOPE" 
+    slope=$MAXSLOPE
+  elif [ $(bc <<< "$slope < $MINSLOPE") -eq 1 ]; then
+    echo "single point slope of $slope < minSlope of $MINSLOPE, using $MINSLOPE" 
+    slope=$MINSLOPE
+  fi 
+fi
+
+yIntercept=$(bc <<< "$yIntercept / 1") # truncate
+slope=$(bc <<< "$slope / 1") # truncate
+
 echo "Calibration - After bounds check, slope=$slope, yIntercept=$yIntercept"
 echo "Calibration - slopeError=$slopeError, yError=$yError"
 

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -39,7 +39,7 @@ function MathSum()
 
   for i in "$@"
   do
-    total=$(bc -l <<< "$total+$i")
+    total=$(bc -l <<< "$total + $i")
   done
 
   echo "$total"
@@ -51,7 +51,7 @@ function MathAvg()
   local total=$(MathSum "${arr[@]}") 
   local avg=0
 
-  avg=$(bc -l <<< "$total/${#arr[@]}")
+  avg=$(bc -l <<< "$total / ${#arr[@]}")
 
   echo "$avg"
 }
@@ -68,7 +68,7 @@ function MathStdDev()
     sqdif=$(bc -l <<< "$sqdif + ($i-$mean)^2") 
   done
   
-  stddev=$(bc -l <<< "sqrt($sqdif/(${#arr[@]}-1))")
+  stddev=$(bc -l <<< "sqrt($sqdif / (${#arr[@]} - 1))")
   echo $stddev
 }
 
@@ -94,17 +94,17 @@ function LeastSquaresRegression()
 
   for (( i=0; i<$n; i++ ))
   do
-    sumXY=$(bc -l <<< "$sumXY + ${xarr[i]}*${yarr[i]}")
-    sumXSq=$(bc -l <<< "$sumXSq + ${xarr[i]}*${xarr[i]}")
-    sumYSq=$(bc -l <<< "$sumYSq + ${yarr[i]}*${yarr[i]}")
+    sumXY=$(bc -l <<< "$sumXY + ${xarr[i]} * ${yarr[i]}")
+    sumXSq=$(bc -l <<< "$sumXSq + ${xarr[i]} * ${xarr[i]}")
+    sumYSq=$(bc -l <<< "$sumYSq + ${yarr[i]} * ${yarr[i]}")
   done  
   
-  r=$(bc -l <<< "($n*$sumXY-$sumX*$sumY)/sqrt((($n*$sumXSq-${sumX}^2)*($n*$sumYSq-${sumY}^2)))")
+  r=$(bc -l <<< "($n * $sumXY - $sumX * $sumY) / sqrt((($n * $sumXSq - ${sumX}^2) * ($n * $sumYSq - ${sumY}^2)))")
 #  echo "r=$r, n=$n, sumXSq=$sumXSq, sumYSq=$sumYSq"
 #  echo "sumY=$sumY, sumX=$sumX, stddevX=$stddevX, stddevY=$stddevY" 
 
   m=$(bc -l <<< "$r * $stddevY / $stddevX ")
-  b=$(bc -l <<< "$meanY - $m*$meanX ")
+  b=$(bc -l <<< "$meanY - $m * $meanX ")
 
 #  echo "m=$m, b=$b" 
 # sets global variables slope and yIntercept
@@ -136,8 +136,8 @@ elif [ "$numx" -gt "0" ]; then
 fi
 
 # truncate and bounds check
-yIntercept=$(bc <<< "$yIntercept/1") # truncate
-slope=$(bc <<< "$slope/1") # truncate
+yIntercept=$(bc <<< "$yIntercept / 1") # truncate
+slope=$(bc <<< "$slope / 1") # truncate
 
 # Set max yIntercept to the minimum of the set of unfiltered values
 maxIntercept=$(MathMin "${yarr[@]}")

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# test.csv order is from oldest calibration at the top to latest calibration at the bottom
+# test.csv in the form of 
+# unfiltered,meterbg,datetime
+#
+# yarr = array of up to 7 last unfiltered values associated with xarr bg meter checks / calibrations
+# xarr = array of up to 7 last bg meter checks / calibrations
+
+INPUT=${1:-"calibrations.csv"}
+OUTPUT=${2:-"calibration-linear.json"}
+
+yarr=( $(tail -7 $INPUT | cut -d ',' -f1 ) )
+xarr=( $(tail -7 $INPUT | cut -d ',' -f2 ) )
+
+echo "Begin calibration using input of $INPUT and output of $OUTPUT"
+
+function MathMin()
+{
+  local arr=("$@")
+  local n=${#arr[@]}
+  local min=${arr[0]}
+   
+  for (( i=1; i<$n; i++ ))
+  do
+    if [ $(bc -l <<< "${arr[$i]} < $min") -eq 1 ]; then
+      min=${arr[$i]}
+    fi
+  done
+
+  echo "$min"
+}
+
+function MathSum()
+{
+  local total=0
+
+  for i in "$@"
+  do
+    total=$(bc -l <<< "$total+$i")
+  done
+
+  echo "$total"
+}
+
+function MathAvg()
+{
+  local arr=("$@")
+  local total=$(MathSum "${arr[@]}") 
+  local avg=0
+
+  avg=$(bc -l <<< "$total/${#arr[@]}")
+
+  echo "$avg"
+}
+
+function MathStdDev()
+{
+  local arr=("$@")
+  local mean=$(MathAvg "${arr[@]}")
+  local sqdif=0
+  local stddev=0
+
+  for i in "${arr[@]}"
+  do
+    sqdif=$(bc -l <<< "$sqdif + ($i-$mean)^2") 
+  done
+  
+  stddev=$(bc -l <<< "sqrt($sqdif/(${#arr[@]}-1))")
+  echo $stddev
+}
+
+
+# Assumes global arrays x and y are set
+# sets global variables slope and yIntercept
+function LeastSquaresRegression()
+{
+  local sumX=$(MathSum "${xarr[@]}")
+  local sumY=$(MathSum "${yarr[@]}")
+  local meanX=$(MathAvg "${xarr[@]}")
+  local meanY=$(MathAvg "${yarr[@]}")
+  local stddevX=$(MathStdDev "${xarr[@]}")
+  local stddevY=$(MathStdDev "${yarr[@]}")
+  local sumXY=0
+  local sumXSq=0
+  local sumYSq=0
+  local r=0
+  local n=${#xarr[@]}
+  local m=0
+  local b=0
+   
+
+  for (( i=0; i<$n; i++ ))
+  do
+    sumXY=$(bc -l <<< "$sumXY + ${xarr[i]}*${yarr[i]}")
+    sumXSq=$(bc -l <<< "$sumXSq + ${xarr[i]}*${xarr[i]}")
+    sumYSq=$(bc -l <<< "$sumYSq + ${yarr[i]}*${yarr[i]}")
+  done  
+  
+  r=$(bc -l <<< "($n*$sumXY-$sumX*$sumY)/sqrt((($n*$sumXSq-${sumX}^2)*($n*$sumYSq-${sumY}^2)))")
+#  echo "r=$r, n=$n, sumXSq=$sumXSq, sumYSq=$sumYSq"
+#  echo "sumY=$sumY, sumX=$sumX, stddevX=$stddevX, stddevY=$stddevY" 
+
+  m=$(bc -l <<< "$r * $stddevY / $stddevX ")
+  b=$(bc -l <<< "$meanY - $m*$meanX ")
+
+#  echo "m=$m, b=$b" 
+# sets global variables slope and yIntercept
+  slope=$m
+  yIntercept=$b
+}
+
+
+
+#echo "${xarr[@]}"
+
+#get the number of calibrations
+numx=${#xarr[@]}
+slope=0
+yIntercept=1000
+
+if [ "$numx" -gt "2" ]; then
+  echo "Calibration records = $numx, using LeastSquaresRegression" 
+  LeastSquaresRegression
+elif [ "$numx" -gt "0" ]; then
+  echo "Calibration records = $numx, using single point linear" 
+  # for less than 3 calibrations, fall back to single point calibration
+  # get the last entry for x and y
+  x=${xarr[-1]}
+  y=${xarr[-1]}
+  yIntercept=0
+  slope=$(bc -l <<< "$y / $x")
+fi
+
+echo "Before bounds check, slope=$slope, yIntercept=$yIntercept"
+# bounds check now
+# truncate slope and yIntercept
+yIntercept=$(bc <<< "$yIntercept/1")
+slope=$(bc <<< "$slope/1")
+maxIntercept=$(MathMin "${yarr[@]}")
+
+if [ $(bc <<< "$slope > 1250") -eq 1 ]; then
+  slope=1350
+elif [ $(bc <<< "$slope < 750") -eq 1 ]; then
+  slope=650
+fi 
+
+if [ $(bc  <<< "$yIntercept > $maxIntercept") -eq 1 ]; then
+  yIntercept=$maxIntercept
+elif [ $(bc <<< "$yIntercept < 0") -eq 1 ]; then
+  yIntercept=0
+fi 
+
+echo "After bounds check, slope=$slope, yIntercept=$yIntercept"
+
+# store the calibration in a json file for use by xdrip-get-entries.sh
+echo "[{\"slope\":$slope, \"yIntercept\":$yIntercept, \"formula\":\"calibratedbg=(unfiltered-yIntercept)/slope\"}]" > $OUTPUT 
+
+echo "Created $OUTPUT"
+cat $OUTPUT
+
+

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -125,13 +125,14 @@ if [ "$numx" -gt "2" ]; then
   echo "Calibration records = $numx, using LeastSquaresRegression" 
   LeastSquaresRegression
 elif [ "$numx" -gt "0" ]; then
-  echo "Calibration records = $numx, using single point linear" 
   # for less than 3 calibrations, fall back to single point calibration
   # get the last entry for x and y
   x=${xarr[-1]}
-  y=${xarr[-1]}
+  y=${yarr[-1]}
   yIntercept=0
   slope=$(bc -l <<< "$y / $x")
+  echo "Calibration records = $numx, using single point linear" 
+  echo "x=$x, y=$y, slope=$slope, yIntercept=0" 
 fi
 
 # truncate and bounds check

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -3,9 +3,24 @@
 # test.csv order is from oldest calibration at the top to latest calibration at the bottom
 # test.csv in the form of 
 # unfiltered,meterbg,datetime
+#Rule 1 - Clear calibration records upon CGM Sensor Change/Insert
+#Rule 2 - Don't allow any BG calibrations or take in any new calibrations 
+#         within 15 minutes of last sensor insert
+#Rule 3 - Only use Single Point Calibration for 1st 12 hours since Sensor insert
+#Rule 4 - Do not store calibration records within 12 hours since Sensor insert. 
+#         Use for SinglePoint calibration, but then discard them
+#Rule 5 - Do not use LSR until we have 4 or more calibration points. 
+#          Use SinglePoint calibration only for less than 4 calibration points. 
+#          SinglePoint simply uses the latest calibration record and assumes 
+#          the yIntercept is 0.
+#Rule 6 - Drop back to SinglePoint calibration if slope is out of bounds 
+#          (>MAXSLOPE or <MINSLOPE)
+#Rule 7 - Drop back to SinglePoint calibration if yIntercept is out of bounds 
+#         (> minimum unfiltered value in calibration record set or 
+#          < - minimum unfiltered value in calibration record set)
 #
-# yarr = array of up to 11 last unfiltered values associated with xarr bg meter checks / calibrations
-# xarr = array of up to 11 last bg meter checks / calibrations
+# yarr = array of last unfiltered values associated w/ bg meter checks 
+# xarr = array of last bg meter check bg values
 
 INPUT=${1:-"calibrations.csv"}
 OUTPUT=${2:-"calibration-linear.json"}

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -4,16 +4,16 @@
 # test.csv in the form of 
 # unfiltered,meterbg,datetime
 #
-# yarr = array of up to 7 last unfiltered values associated with xarr bg meter checks / calibrations
-# xarr = array of up to 7 last bg meter checks / calibrations
+# yarr = array of up to 11 last unfiltered values associated with xarr bg meter checks / calibrations
+# xarr = array of up to 11 last bg meter checks / calibrations
 
 INPUT=${1:-"calibrations.csv"}
 OUTPUT=${2:-"calibration-linear.json"}
 MAXSLOPE=1350
 MINSLOPE=550
 
-yarr=( $(tail -7 $INPUT | cut -d ',' -f1 ) )
-xarr=( $(tail -7 $INPUT | cut -d ',' -f2 ) )
+yarr=( $(tail -11 $INPUT | cut -d ',' -f1 ) )
+xarr=( $(tail -11 $INPUT | cut -d ',' -f2 ) )
 
 echo "Begin calibration using input of $INPUT and output of $OUTPUT"
 

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -110,6 +110,19 @@ function LeastSquaresRegression()
 # sets global variables slope and yIntercept
   slope=$m
   yIntercept=$b
+
+# calculate error
+  local varSum=0
+  for (( j=0; j<$n; j++ ))
+  do
+    varSum=$(bc -l <<< "$varSum + (${yarr[$j]} - $b - $m * ${xarr[$j]})^2")   
+  done
+
+  local delta=$(bc -l <<< "$n * $sumXSq - ($sumX)^2")  
+  local vari=$(bc -l <<< "1.0 / ($n - 2.0) * $varSum")
+  
+  yError=$(bc -l <<< "sqrt($vari / $delta * $sumXSq)") 
+  slopeError=$(bc -l <<< "sqrt($n / $delta * $vari)")
 }
 
 
@@ -120,6 +133,8 @@ function LeastSquaresRegression()
 numx=${#xarr[@]}
 slope=0
 yIntercept=1000
+slopeError=0
+yError=0
 
 if [ "$numx" -gt "2" ]; then
   echo "Calibration records = $numx, using LeastSquaresRegression" 
@@ -138,6 +153,8 @@ fi
 # truncate and bounds check
 yIntercept=$(bc <<< "$yIntercept / 1") # truncate
 slope=$(bc <<< "$slope / 1") # truncate
+yError=$(bc <<< "$yError / 1") # truncate
+slopeError=$(bc <<< "$slopeError / 1") # truncate
 
 # Set max yIntercept to the minimum of the set of unfiltered values
 maxIntercept=$(MathMin "${yarr[@]}")
@@ -159,7 +176,7 @@ fi
 echo "After bounds check, slope=$slope, yIntercept=$yIntercept"
 
 # store the calibration in a json file for use by xdrip-get-entries.sh
-echo "[{\"slope\":$slope, \"yIntercept\":$yIntercept, \"formula\":\"calibratedbg=(unfiltered-yIntercept)/slope\"}]" > $OUTPUT 
+echo "[{\"slope\":$slope, \"yIntercept\":$yIntercept, \"formula\":\"calibratedbg=(unfiltered-yIntercept)/slope\", \"yError\":$yError, \"slopeError\":${slopeError}}]" > $OUTPUT 
 
 echo "Created $OUTPUT"
 cat $OUTPUT

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -11,11 +11,18 @@ INPUT=${1:-"calibrations.csv"}
 OUTPUT=${2:-"calibration-linear.json"}
 MAXSLOPE=1350
 MINSLOPE=550
+MAXRECORDS=8
+MINRECORDSFORLSR=3
 
-yarr=( $(tail -11 $INPUT | cut -d ',' -f1 ) )
-xarr=( $(tail -11 $INPUT | cut -d ',' -f2 ) )
+yarr=( $(tail -$MAXRECORDS $INPUT | cut -d ',' -f1 ) )
+xarr=( $(tail -$MAXRECORDS $INPUT | cut -d ',' -f2 ) )
 
 echo "Begin calibration using input of $INPUT and output of $OUTPUT"
+
+# Future how to compare date values if we want to limit calibration set to a timeframe
+#    dt1970arr[$i]=`date +%s --date="${dtarr[$i]}"`
+#    set initial i value based on date differences
+# dtarr=( $(tail -11 $INPUT | cut -d ',' -f3 ) )
 
 function MathMin()
 {
@@ -23,6 +30,7 @@ function MathMin()
   local n=${#arr[@]}
   local min=${arr[0]}
    
+
   for (( i=1; i<$n; i++ ))
   do
     if [ $(bc -l <<< "${arr[$i]} < $min") -eq 1 ]; then
@@ -136,11 +144,13 @@ yIntercept=1000
 slopeError=0
 yError=0
 
-if [ "$numx" -gt "2" ]; then
+if [ $(bc -l <<< "$numx >= $MINRECORDSFORLSR") -eq 1 ]; then
   echo "Calibration records = $numx, using LeastSquaresRegression" 
   LeastSquaresRegression
+  calibrationType="LeastSquaresRegression"
 elif [ "$numx" -gt "0" ]; then
-  # for less than 3 calibrations, fall back to single point calibration
+  # for less than $MINRECORDSFORLSR calibrations, 
+  # fall back to single point calibration
   # get the last entry for x and y
   x=${xarr[-1]}
   y=${yarr[-1]}
@@ -148,6 +158,7 @@ elif [ "$numx" -gt "0" ]; then
   slope=$(bc -l <<< "$y / $x")
   echo "Calibration records = $numx, using single point linear" 
   echo "x=$x, y=$y, slope=$slope, yIntercept=0" 
+  calibrationType="SinglePoint"
 fi
 
 # truncate and bounds check
@@ -177,9 +188,11 @@ echo "Calibration - After bounds check, slope=$slope, yIntercept=$yIntercept"
 echo "Calibration - slopeError=$slopeError, yError=$yError"
 
 # store the calibration in a json file for use by xdrip-get-entries.sh
-echo "[{\"slope\":$slope, \"yIntercept\":$yIntercept, \"formula\":\"calibratedbg=(unfiltered-yIntercept)/slope\", \"yError\":$yError, \"slopeError\":${slopeError}}]" > $OUTPUT 
+echo "[{\"slope\":$slope, \"yIntercept\":$yIntercept, \"formula\":\"calibratedbg=(unfiltered-yIntercept)/slope\", \"yError\":$yError, \"slopeError\":${slopeError}, \"numCalibrations\":${numx}, \"calibrationType\":\"${calibrationType}\"}]" > $OUTPUT 
 
 echo "Calibration - Created $OUTPUT"
 cat $OUTPUT
+
+#ConvertDateArray
 
 

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -152,8 +152,8 @@ fi
 
 if [ $(bc  <<< "$yIntercept > $maxIntercept") -eq 1 ]; then
   yIntercept=$maxIntercept
-elif [ $(bc <<< "$yIntercept < 0") -eq 1 ]; then
-  yIntercept=0
+elif [ $(bc <<< "$yIntercept < -30000") -eq 1 ]; then
+  yIntercept=-30000
 fi 
 
 echo "After bounds check, slope=$slope, yIntercept=$yIntercept"

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -182,8 +182,8 @@ fi
 
 if [ $(bc  <<< "$yIntercept > $maxIntercept") -eq 1 ]; then
   yIntercept=$maxIntercept
-elif [ $(bc <<< "$yIntercept < -30000") -eq 1 ]; then
-  yIntercept=-30000
+elif [ $(bc <<< "$yIntercept < (0 - $maxIntercept)") -eq 1 ]; then
+  yIntercept=$(bc <<< "0 - $maxIntercept")
 fi 
 
 echo "Calibration - After bounds check, slope=$slope, yIntercept=$yIntercept"

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -9,7 +9,7 @@
 
 INPUT=${1:-"calibrations.csv"}
 OUTPUT=${2:-"calibration-linear.json"}
-MAXSLOPE=1350
+MAXSLOPE=1450
 MINSLOPE=550
 MAXRECORDS=8
 MINRECORDSFORLSR=4
@@ -182,9 +182,13 @@ maxIntercept=$(MathMin "${yarr[@]}")
 echo "Calibration - Before bounds check, slope=$slope, yIntercept=$yIntercept"
 
 if [ $(bc <<< "$slope > $MAXSLOPE") -eq 1 ]; then
-  slope=$MAXSLOPE
+  # fall back to Single Point in this case
+  echo "slope of $slope > maxSlope of $MAXSLOPE, using single point linear" 
+  SinglePointCalibration
 elif [ $(bc <<< "$slope < $MINSLOPE") -eq 1 ]; then
-  slope=$MINSLOPE
+  # fall back to Single Point in this case
+  echo "slope of $slope < minSlope of $MINSLOPE, using single point linear" 
+  SinglePointCalibration
 fi 
 
 if [ $(bc  <<< "$yIntercept > $maxIntercept") -eq 1 ]; then

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -13,6 +13,7 @@ MAXSLOPE=1350
 MINSLOPE=550
 MAXRECORDS=8
 MINRECORDSFORLSR=3
+rSquared=0
 
 yarr=( $(tail -$MAXRECORDS $INPUT | cut -d ',' -f1 ) )
 xarr=( $(tail -$MAXRECORDS $INPUT | cut -d ',' -f2 ) )
@@ -108,6 +109,7 @@ function LeastSquaresRegression()
   done  
   
   r=$(bc -l <<< "($n * $sumXY - $sumX * $sumY) / sqrt((($n * $sumXSq - ${sumX}^2) * ($n * $sumYSq - ${sumY}^2)))")
+  rSquared=$(bc -l <<< "(${r})^2")
 #  echo "r=$r, n=$n, sumXSq=$sumXSq, sumYSq=$sumYSq"
 #  echo "sumY=$sumY, sumX=$sumX, stddevX=$stddevX, stddevY=$stddevY" 
 
@@ -188,7 +190,7 @@ echo "Calibration - After bounds check, slope=$slope, yIntercept=$yIntercept"
 echo "Calibration - slopeError=$slopeError, yError=$yError"
 
 # store the calibration in a json file for use by xdrip-get-entries.sh
-echo "[{\"slope\":$slope, \"yIntercept\":$yIntercept, \"formula\":\"calibratedbg=(unfiltered-yIntercept)/slope\", \"yError\":$yError, \"slopeError\":${slopeError}, \"numCalibrations\":${numx}, \"calibrationType\":\"${calibrationType}\"}]" > $OUTPUT 
+echo "[{\"slope\":$slope, \"yIntercept\":$yIntercept, \"formula\":\"calibratedbg=(unfiltered-yIntercept)/slope\", \"yError\":$yError, \"slopeError\":${slopeError}, \"rSquared\":${rSquared}, \"numCalibrations\":${numx}, \"calibrationType\":\"${calibrationType}\"}]" > $OUTPUT 
 
 echo "Calibration - Created $OUTPUT"
 cat $OUTPUT

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -10,7 +10,7 @@
 INPUT=${1:-"calibrations.csv"}
 OUTPUT=${2:-"calibration-linear.json"}
 MAXSLOPE=1350
-MINSLOPE=650
+MINSLOPE=550
 
 yarr=( $(tail -7 $INPUT | cut -d ',' -f1 ) )
 xarr=( $(tail -7 $INPUT | cut -d ',' -f2 ) )

--- a/calc-calibration.sh
+++ b/calc-calibration.sh
@@ -159,7 +159,7 @@ slopeError=$(bc <<< "$slopeError / 1") # truncate
 # Set max yIntercept to the minimum of the set of unfiltered values
 maxIntercept=$(MathMin "${yarr[@]}")
 
-echo "Before bounds check, slope=$slope, yIntercept=$yIntercept"
+echo "Calibration - Before bounds check, slope=$slope, yIntercept=$yIntercept"
 
 if [ $(bc <<< "$slope > $MAXSLOPE") -eq 1 ]; then
   slope=$MAXSLOPE
@@ -173,12 +173,13 @@ elif [ $(bc <<< "$yIntercept < -30000") -eq 1 ]; then
   yIntercept=-30000
 fi 
 
-echo "After bounds check, slope=$slope, yIntercept=$yIntercept"
+echo "Calibration - After bounds check, slope=$slope, yIntercept=$yIntercept"
+echo "Calibration - slopeError=$slopeError, yError=$yError"
 
 # store the calibration in a json file for use by xdrip-get-entries.sh
 echo "[{\"slope\":$slope, \"yIntercept\":$yIntercept, \"formula\":\"calibratedbg=(unfiltered-yIntercept)/slope\", \"yError\":$yError, \"slopeError\":${slopeError}}]" > $OUTPUT 
 
-echo "Created $OUTPUT"
+echo "Calibration - Created $OUTPUT"
 cat $OUTPUT
 
 

--- a/calc-noise.sh
+++ b/calc-noise.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+INPUT=${1:-"/var/log/openaps/g5.csv"}
+MAXRECORDS=8
+MINRECORDS=4
+XINCREMENT=10000
+yarr=( $(tail -$MAXRECORDS $INPUT | cut -d ',' -f2 ) )
+n=${#yarr[@]}
+
+# sod = sum of distances
+sod=0
+overallsod=0
+
+for (( i=1; i<$n; i++ ))
+do
+  y1=${yarr[$i]}
+  y2=${yarr[$i-1]}
+
+  sod=$(bc -l <<< "$sod + sqrt(($XINCREMENT)^2 + ($y1 - $y2)^2)")
+done  
+
+overallsod=$(bc -l <<< "sqrt((${yarr[$n-1]} - ${yarr[0]})^2 + ($XINCREMENT*($n - 1))^2)")
+
+if [ $(bc -l <<< "$sod == 0") -eq 1 ]; then
+  # assume no noise if no records
+  noise = 0
+else
+  noise=$(bc -l <<< "1 - ($overallsod/$sod)")
+fi
+echo $noise
+
+

--- a/logger/index.js
+++ b/logger/index.js
@@ -12,7 +12,7 @@ transmitter.on('glucose', glucose => {
       'device': 'DexcomR4',
       'date': glucose.readDate,
       'dateString': new Date(glucose.readDate).toISOString(),
-      'sgv': Math.round(glucose.unfiltered),
+      'sgv': Math.round(glucose.unfiltered/1000),
       'direction': 'None',
       'type': 'sgv',
       'filtered': Math.round(glucose.filtered),

--- a/logger/index.js
+++ b/logger/index.js
@@ -24,7 +24,7 @@ transmitter.on('glucose', glucose => {
     }];
     const data = JSON.stringify(entry);
 
-  if(glucose.unfiltered > 500 || glucose.unfiltered < 30) // for safety, I'm assuming it is erroneous and ignoring
+  if(glucose.unfiltered > 500000 || glucose.unfiltered < 30000) // for safety, I'm assuming it is erroneous and ignoring
     {
       console.log("Error - bad glucose data, not processing");
       process.exit();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",
@@ -16,7 +16,8 @@
     "xdrip-get-entries": "./xdrip-get-entries.sh",
     "post-xdripAPS": "./post-xdripAPS.sh",
     "post-ns": "./post-ns.sh",
-    "calc-calibration": "./calc-calibration.sh"
+    "calc-calibration": "./calc-calibration.sh",
+    "calc-calibration": "./calc-noise.sh"
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",
@@ -10,7 +10,7 @@
     "global-install": "npm install && sudo npm install -g && sudo npm link && sudo npm link logger"
   },
   "dependencies": {
-    "xdrip-js": "thebookins/xdrip-js#v1.1.0"
+    "xdrip-js": "thebookins/xdrip-js#v1.1.2"
   },
   "bin": {
     "xdrip-get-entries": "./xdrip-get-entries.sh",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "bin": {
     "xdrip-get-entries": "./xdrip-get-entries.sh",
     "post-xdripAPS": "./post-xdripAPS.sh",
-    "post-ns": "./post-ns.sh"
+    "post-ns": "./post-ns.sh",
     "calc-calibration": "./calc-calibration.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "xdrip-get-entries": "./xdrip-get-entries.sh",
     "post-xdripAPS": "./post-xdripAPS.sh",
     "post-ns": "./post-ns.sh"
+    "calc-calibration": "./calc-calibration.sh"
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdrip-js-logger",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "main": "logger/index.js",
   "author": "Paul Dickens",

--- a/post-ns.sh
+++ b/post-ns.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+export NIGHTSCOUT_HOST
+export API_SECRET
+
 ns_url="${NIGHTSCOUT_HOST}"
 ns_secret="${API_SECRET}"
     

--- a/post-ns.sh
+++ b/post-ns.sh
@@ -11,7 +11,7 @@ ns_secret="${API_SECRET}"
 curl_status=-1
 
 if [ -e $1 ]; then
-  curl -f -m 30 -s -X POST -d @$1 \
+  curl --compressed -f -m 30 -s -X POST -d @$1 \
   -H "API-SECRET: $ns_secret" \
   -H "Content-Type: application/json" \
   "${ns_url}/api/v1/entries.json"

--- a/post-ns.sh
+++ b/post-ns.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source ~/.bash_profile
+
 export NIGHTSCOUT_HOST
 export API_SECRET
 

--- a/post-xdripAPS.sh
+++ b/post-xdripAPS.sh
@@ -5,6 +5,8 @@
 # 0 ==> success
 # other ==> curl_status
 
+export API_SECRET
+
 ns_url="http://127.0.0.1:5000"
 ns_secret="${API_SECRET}"
 

--- a/post-xdripAPS.sh
+++ b/post-xdripAPS.sh
@@ -11,7 +11,7 @@ ns_secret="${API_SECRET}"
 curl_status=-1
  
 if [ -e $1 ]; then
-  curl -f -m 30 -s -X POST -d @$1 \
+  curl --compressed -f -m 30 -s -X POST -d @$1 \
   -H "API-SECRET: $ns_secret" \
   -H "Content-Type: application/json" \
   "${ns_url}/api/v1/entries"

--- a/post-xdripAPS.sh
+++ b/post-xdripAPS.sh
@@ -5,6 +5,8 @@
 # 0 ==> success
 # other ==> curl_status
 
+source ~/.bash_profile
+
 export API_SECRET
 
 ns_url="http://127.0.0.1:5000"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -75,6 +75,8 @@ else
   calibration=0
   ns_url="${NIGHTSCOUT_HOST}"
   METERBG_NS_RAW="meterbg_ns_raw.json"
+  rm $METERBG_NS_RAW # clear any old meterbg curl responses
+
 
   # look for a bg check from pumphistory (direct from meter->openaps):
   meterbgafter=$(date -d "7 minutes ago" -Iminutes)

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -191,7 +191,7 @@ else
   fi
 
   echo "Posting blood glucose record(s) to NightScout"
-  ./post-ns.sh ./entry-ns.json && (echo; echo "Upload to NightScout of xdrip entry worked ... removing ./entry-backfill.json"; rm ./entry-backfill.json) || (echo; echo "Upload to NS of xdrip entry did not work ... saving for upload when network is restored"; cp ./entry-ns.json ./entry-backfill.json)
+  ./post-ns.sh ./entry-ns.json && (echo; echo "Upload to NightScout of xdrip entry worked ... removing ./entry-backfill.json"; rm -f ./entry-backfill.json) || (echo; echo "Upload to NS of xdrip entry did not work ... saving for upload when network is restored"; cp ./entry-ns.json ./entry-backfill.json)
   echo
 fi
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -97,7 +97,7 @@ else
   fi
 
   if [ -e $CALIBRATION_STORAGE ]; then
-    calibration=$(cat $CALIBRATION_STORAGE | jq -M '.[0] | .calibration')thenjesus cross pendant
+    calibration=$(cat $CALIBRATION_STORAGE | jq -M '.[0] | .calibration')
     calibratedglucose=`expr $glucose + $calibration`
     echo "After calibration calibratedglucose =$calibratedglucose"
   fi

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
-# requirements
-#   bt-device --> bluez-tools
-#      sudo apt-get install bluez-tools
-#   xdrip-js
-#
+
+glucoseType='.[0].unfiltered'
 
 cd /root/src/xdrip-js-logger
 
@@ -12,8 +9,12 @@ date
 
 
 if [ -e "./entry.json" ] ; then
-  lastGlucose=$(cat ./entry.json | jq -M '.[0].unfiltered')
+  lastGlucose=$(cat ./entry.json | jq -M $glucoseType)
   lastUnfiltered=$(cat ./entry.json | jq -M '.[0].unfiltered')
+  lastAfter=$(date -u -d "5 minutes ago" -Iminutes)
+  lastPostStr="'.[0] | select(.dateString > \"$lastAfter\") | .glucose'"
+  lastPostCal=$(cat ./entry.json | bash -c "jq -M $lastPostStr")
+  #echo lastAfter=$lastAfter, lastPostStr=$lastPostStr, lastPostCal=$lastPostCal
   mv ./entry.json ./last-entry.json
 fi
 
@@ -25,13 +26,11 @@ echo "Removing existing Dexcom bluetooth connection = ${id}"
 bt-device -r $id
 
 echo "Calling xdrip-js ... node logger $transmitter"
-timeout 360s node logger $transmitter
-#DEBUG=transmitter,bluetooth-manager node logger 410BFE
+DEBUG=smp,transmitter,bluetooth-manager timeout 360s node logger $transmitter
 echo "after xdrip-js bg record below ..."
-
 cat ./entry.json
 
-glucose=$(cat ./entry.json | jq -M '.[0].unfiltered')
+glucose=$(cat ./entry.json | jq -M $glucoseType)
 echo
 
 if [ "${glucose}" == "" ] ; then
@@ -41,7 +40,11 @@ if [ "${glucose}" == "" ] ; then
   rm ./entry.json
 else
 
-  dg=`expr $glucose - $lastGlucose`
+  if [ "${lastGlucose}" == "" ] ; then
+    dg=0
+  else
+    dg=`expr $glucose - $lastGlucose`
+  fi
 
   # begin try out averaging last two entries ...
   da=${dg}
@@ -61,9 +64,7 @@ else
   unfiltered=$(cat ./entry.json | jq -M '.[0].unfiltered')
   filtered=$(cat ./entry.json | jq -M '.[0].filtered')
   glucoseg5=$(cat ./entry.json | jq -M '.[0].glucose')
-#  logdate=$(cat ./entry.json | jq -M '.[0].dateString')
   datetime=$(date +"%Y-%m-%d %H:%M")
-
   # end log to csv file logic for g5 outputs
 
   # begin calibration logic - look for calibration from NS, use existing calibration or none
@@ -72,23 +73,55 @@ else
   METERBG_NS_RAW="meterbg_ns_raw.json"
   CALIBRATION_STORAGE="calibration.json"
 
-  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "6 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+  # remove old calibration storage when sensor change occurs
+  # calibrate after 15 minutes of sensor change time entered in NS
+  curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "15 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
+  if [ $? == 0 ]; then
+    rm $CALIBRATION_STORAGE
+  fi
 
-  meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
-  meterbg=$(cat $METERBG_NS_RAW | jq -M '.[0] | .glucose')
-  meterbg="${meterbg%\"}"
-  meterbg="${meterbg#\"}"
-  if [ "$meterbgunits" == "mmol" ]; then
-    meterbg=$(echo $meterbg "*18" | bc)
+  # look for a bg check from pumphistory (direct from meter->openaps):
+  meterbgafter=$(date -d "7 minutes ago" -Iminutes)
+  meterjqstr="'.[] | select(._type == \"BGReceived\") | select(.timestamp > \"$meterbgafter\") | .amount'"
+  meterbg=$(bash -c "jq $meterjqstr ~/myopenaps/monitor/pumphistory-merged.json")
+  # TBD: meter BG from pumphistory doesn't support mmol yet - has no units...
+  echo "meterbg from pumphistory: $meterbg"
+
+  if [ "$meterbg" == "" ]; then
+    # look for a bg check from NS (& test NS record for local time or UTC)
+    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null >> $METERBG_NS_RAW
+    isUTC=$(jq ".[0].created_at[-1:]" $METERBG_NS_RAW)
+    if [ "$isUTC" != '"Z"' ]; then
+      curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+      isUTC=$(jq ".[0].created_at[-1:]" $METERBG_NS_RAW)
+      if [ "$isUTC" == '"Z"' ]; then
+        echo > $METERBG_NS_RAW
+      fi
+    fi
+
+    meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
+    meterbg=$(cat $METERBG_NS_RAW | jq -M '.[0] | .glucose')
+    meterbg="${meterbg%\"}"
+    meterbg="${meterbg#\"}"
+    if [ "$meterbgunits" == "mmol" ]; then
+      meterbg=$(echo $meterbg "*18" | bc)
+    fi
+    echo "meterbg from nightscout: $meterbg"
   fi
 
   if [ "$meterbg" == "null" ]; then
     :
   else
     if [ $meterbg -lt 400 -a $meterbg -gt 40 ]; then
-      calibration=`expr $meterbg - $glucose`
-      echo "calibration=$calibration, meterbg=$meterbg, glucose=$glucose"
-      if [ $calibration -lt 30 -a $calibration -gt -50 ]; then
+      calibrationBg=$meterbg
+      if [ "$lastPostCal" != "" ]; then
+        if [ $lastPostCal -lt 400 -a $lastPostCal -gt 40 ]; then
+          calibrationBg=$((($meterbg + $lastPostCal) / 2))
+        fi
+      fi
+      calibration=`expr $calibrationBg - $glucose`
+      echo "calibration=$calibration, meterbg=$meterbg, lastPostCal=$lastPostCal, calibrationBg=$calibrationBg, glucose=$glucose"
+      if [ $calibration -lt 60 -a $calibration -gt -80 ]; then
         # another safety check, but this is a good calibration
         echo "[{\"calibration\":${calibration}}]" > $CALIBRATION_STORAGE
         cp $METERBG_NS_RAW meterbg-ns-backup.json
@@ -100,6 +133,22 @@ else
     calibration=$(cat $CALIBRATION_STORAGE | jq -M '.[0] | .calibration')
     calibratedglucose=`expr $glucose + $calibration`
     echo "After calibration calibratedglucose =$calibratedglucose"
+  else
+    echo "No valid calibration yet - exiting"
+    bt-device -r $id
+    exit
+  fi
+
+  if [ $calibratedglucose -gt 400 -o $calibratedglucose -lt 40 ]; then
+    echo "Glucose $calibratedglucose out of range [40,400] - exiting"
+    bt-device -r $id
+    exit
+  fi
+
+  if [ $dg -gt 50 -o $dg -lt -50 ]; then
+    echo "Change $dg out of range [-50,50] - exiting"
+    bt-device -r $id
+    exit
   fi
 
    cp entry.json entry-before-calibration.json
@@ -119,7 +168,7 @@ else
 
   if [ ${dg} -lt -10 ]; then
      direction='DoubleDown'
-  elif [ ${dg} -lt -7 ]; then 
+  elif [ ${dg} -lt -7 ]; then
      direction='SingleDown'
   elif [ ${dg} -lt -3 ]; then
      direction='FortyFiveDown'
@@ -158,7 +207,7 @@ else
   fi
 
   echo "Posting blood glucose record(s) to NightScout"
-  ./post-ns.sh ./entry-ns.json && (echo; echo "Upload to NightScout of xdrip entry worked ... removing ./entry-backfill.json"; rm ./entry-backfill.json) || (echo; echo "Upload to NS of xdrip entry did not work ... saving for upload when network is restored"; cp ./entry-ns.json ./entry-backfill.json)
+  ./post-ns.sh ./entry-ns.json && (echo; echo "Upload to NightScout of xdrip entry worked ... removing ./entry-backfill.json"; rm -f ./entry-backfill.json) || (echo; echo "Upload to NS of xdrip entry did not work ... saving for upload when network is restored"; cp ./entry-ns.json ./entry-backfill.json)
   echo
 fi
 
@@ -166,4 +215,3 @@ bt-device -r $id
 echo "Finished xdrip-get-entries.sh"
 date
 echo
-

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -166,3 +166,4 @@ bt-device -r $id
 echo "Finished xdrip-get-entries.sh"
 date
 echo
+

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -10,6 +10,15 @@ cd /root/src/xdrip-js-logger
 echo "Starting xdrip-get-entries.sh"
 date
 
+CALIBRATION_STORAGE="calibration.json"
+
+# remove old calibration storage when sensor change occurs
+# calibrate after 15 minutes of sensor change time entered in NS
+curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "15 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
+if [ $? == 0 ]; then
+  echo "sensor change - removing calibration"
+  rm $CALIBRATION_STORAGE
+fi
 
 if [ -e "./entry.json" ] ; then
   lastGlucose=$(cat ./entry.json | jq -M '.[0].unfiltered')
@@ -35,6 +44,20 @@ echo "after xdrip-js bg record below ..."
 
 cat ./entry.json
 
+# re-scale unfiltered from /1000 to /$calSlope
+# (NOTE: ideally xdrip-js should be changed to not scale down unfiltered and
+#        filtered by 1000, and we should also cleanup this script to avoid
+#        scaling unfiltered directly, i.e., use a variable, as there values
+#        should be passed to NS unaltered. This will become more important
+#        when we also send it a cal record...)
+calSlope=750
+scaled=$(cat ./entry.json | jq -M '.[0].unfiltered')
+scaled=$(($scaled * 1000 / $calSlope))
+tmp=$(mktemp)
+jq ".[0].unfiltered = $scaled" entry.json > "$tmp" && mv "$tmp" entry.json
+echo "after unfiltered-scale bg record below ..."
+cat ./entry.json
+
 glucose=$(cat ./entry.json | jq -M '.[0].unfiltered')
 echo
 
@@ -45,14 +68,18 @@ if [ "${glucose}" == "" ] ; then
   rm ./entry.json
 else
 
-  dg=`expr $glucose - $lastGlucose`
+  if [ "${lastGlucose}" == "" ] ; then
+    dg=0
+  else
+    dg=`expr $glucose - $lastGlucose`
+  fi
 
   # begin try out averaging last two entries ...
   da=${dg}
   if [ ${da} -lt 0 ]; then
     da=`expr 0 - $da`
   fi
-  if [ ${da} -lt 45 -a ${da} -gt 6 ]; then
+  if [ ${da} -gt 6 ]; then
      echo "Before Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=${glucose}"
      glucose=`expr $glucose + $lastGlucose`
      glucose=`expr $glucose / 2`
@@ -74,22 +101,13 @@ else
   calibration=0
   ns_url="${NIGHTSCOUT_HOST}"
   METERBG_NS_RAW="meterbg_ns_raw.json"
-  CALIBRATION_STORAGE="calibration.json"
-
-
-  # remove old calibration storage when sensor change occurs
-  # calibrate after 15 minutes of sensor change time entered in NS
-  curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "15 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
-  if [ $? == 0 ]; then
-    rm $CALIBRATION_STORAGE
-  fi
 
   # look for a bg check from pumphistory (direct from meter->openaps):
   meterbgafter=$(date -d "7 minutes ago" -Iminutes)
   meterjqstr="'.[] | select(._type == \"BGReceived\") | select(.timestamp > \"$meterbgafter\") | .amount'"
   meterbg=$(bash -c "jq $meterjqstr ~/myopenaps/monitor/pumphistory-merged.json")
   # TBD: meter BG from pumphistory doesn't support mmol yet - has no units...
-  echo "meterbg from pumphistory: $meterbg" 
+  echo "meterbg from pumphistory: $meterbg"
 
   if [ "$meterbg" == "" ]; then
     # look for a bg check from NS (& test NS record for local time or UTC)
@@ -110,7 +128,7 @@ else
     if [ "$meterbgunits" == "mmol" ]; then
       meterbg=$(echo $meterbg "*18" | bc)
     fi
-    echo "meterbg from nightscout: $meterbg" 
+    echo "meterbg from nightscout: $meterbg"
   fi
 
   if [ "$meterbg" == "null" ]; then
@@ -143,6 +161,18 @@ else
     exit
   fi
 
+  if [ $calibratedglucose -gt 400 -o $calibratedglucose -lt 40 ]; then
+    echo "Glucose $calibratedglucose out of range [40,400] - exiting"
+    bt-device -r $id
+    exit
+  fi
+
+  if [ $dg -gt 50 -o $dg -lt -50 ]; then
+    echo "Change $dg out of range [-50,50] - exiting"
+    bt-device -r $id
+    exit
+  fi
+
    cp entry.json entry-before-calibration.json
 
    tmp=$(mktemp)
@@ -160,7 +190,7 @@ else
 
   if [ ${dg} -lt -10 ]; then
      direction='DoubleDown'
-  elif [ ${dg} -lt -7 ]; then 
+  elif [ ${dg} -lt -7 ]; then
      direction='SingleDown'
   elif [ ${dg} -lt -3 ]; then
      direction='FortyFiveDown'
@@ -179,10 +209,10 @@ else
   cat entry.json | jq ".[0].direction = \"$direction\"" > entry-xdrip.json
 
   if [ ! -f "/var/log/openaps/g5.csv" ]; then
-    echo "datetime,unfiltered,filtered,glucoseg5,glucose,calibratedglucose,direction,calibration" > /var/log/openaps/g5.csv
+    echo "datetime,unfiltered,filtered,glucoseg5,glucose,calibratedglucose,slope,direction,calibration" > /var/log/openaps/g5.csv
   fi
 
-  echo "${datetime},${unfiltered},${filtered},${glucoseg5},${glucose},${calibratedglucose},${direction},${calibration}" >> /var/log/openaps/g5.csv
+  echo "${datetime},${unfiltered},${filtered},${glucoseg5},${glucose},${calibratedglucose},${calSlope},${direction},${calibration}" >> /var/log/openaps/g5.csv
 
   echo "Posting glucose record to xdripAPS"
   ./post-xdripAPS.sh ./entry-xdrip.json

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -130,6 +130,9 @@ if [ -e $CAL_OUTPUT ]; then
   slopeError=`jq -M '.[0] .slopeError' calibration-linear.json` 
   yError=`jq -M '.[0] .yError' calibration-linear.json` 
   calibrationType=`jq -M '.[0] .calibrationType' calibration-linear.json` 
+  calibrationType="${calibrationType%\"}"
+  calibrationType="${calibrationType#\"}"
+  numCalibrations=`jq -M '.[0] .numCalibrations' calibration-linear.json` 
   rSquared=`jq -M '.[0] .rSquared' calibration-linear.json` 
 else
   # exit until we have a valid calibration record
@@ -152,12 +155,16 @@ echo "After calibration calibratedBG =$calibratedBG, slope=$slope, yIntercept=$y
 # CI = a1 * BG^2 + a2 * BG + a3
 # a1=-0.1667, a2=25.66667, a3=-977.5
 c=$calibratedBG
-if [ "$calibrationType" == "SinglePoint" ]; then
+echo "numCalibrations=$numCalibrations, calibrationType=$calibrationType, c=$c"
+if [ "$calibrationType" = "SinglePoint" ]; then
+  echo "inside CalibrationType=$calibrationType, c=$c"
   if [ $(bc <<< "$c > 69") -eq 1 -a $(bc <<< "$c < 85") -eq 1 ]; then
     echo "SinglePoint calibration calculating corrective intercept"
     echo "Before CI, BG=$c"
     calibratedBG=$(bc <<< "$c - (-0.16667 * ${c}^2 + 25.6667 * ${c} - 977.5)")
     echo "After CI, BG=$calibratedBG"
+  else
+    echo "bg not in range [70-84]"
   fi
 fi
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -49,8 +49,8 @@ function ClearCalibrationCache()
 UTC=" -u "
 # check UTC to begin with and use UTC flag for any curls
 curl --compressed -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?count=1&find\[created_at\]\[\$gte\]=$(date -d "2400 hours ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null  > ./testUTC.json  
-createdAt=$(jq ".[0].created_at" ./testUTC.json)
 if [ $? == 0 ]; then
+  createdAt=$(jq ".[0].created_at" ./testUTC.json)
   if [ $"$createdAt" == "" ]; then
     echo "You must record a \"Sensor Insert\" in Nightscout before Logger will run" 
     echo -e "exiting\n"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -92,7 +92,7 @@ else
     if [[ $createdAt == *"Z"* ]]; then
        echo "meterbg within 7 minutes using UTC time comparison."       
     else   
-      if [ "$createdAt" != "NULL" -a "$createdAt" != "" ]; then
+      if [ "$createdAt" != "null" -a "$createdAt" != "" ]; then
         curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
         echo "meterbg within 7 minutes using non-UTC time comparison."
       fi

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -119,7 +119,7 @@ else
 
   if [ ${dg} -lt -10 ]; then
      direction='DoubleDown'
-  elif [ ${dg} -lt -7 ]; 
+  elif [ ${dg} -lt -7 ]; then 
      direction='SingleDown'
   elif [ ${dg} -lt -3 ]; then
      direction='FortyFiveDown'

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -315,7 +315,7 @@ if [ ! -f "/var/log/openaps/g5.csv" ]; then
 fi
 
 
-# calculate noise and position it for updating the entry sent to NS and xdripAPS
+# calculate the noise and position it for updating the entry sent to NS and xdripAPS
 noise=$(./calc-noise.sh)
 
 noiseSend=0 # unknown

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -8,6 +8,7 @@ echo "Starting xdrip-get-entries.sh"
 date
 
 # Check required environment variables
+source ~/.bash_profile
 export API_SECRET
 export NIGHTSCOUT_HOST
 if [ "$API_SECRET" = "" ]; then

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -56,7 +56,7 @@ else
     da=$(bc <<< "0 - $da")
   fi
 
-  if [ "$da" -lt "45" -a "$da" -gt "6" ]; then
+  if [ "$da" -lt "45" -a "$da" -gt "15" ]; then
      echo "Before Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=$glucose"
      glucose=$(bc <<< "($glucose + $lastGlucose)/2")
      dg=$(bc <<< "$glucose - $lastGlucose")

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -133,6 +133,8 @@ fi
 if [ -e $CAL_OUTPUT ]; then
   slope=`jq -M '.[0] .slope' calibration-linear.json` 
   yIntercept=`jq -M '.[0] .yIntercept' calibration-linear.json` 
+  slopeError=`jq -M '.[0] .slopeError' calibration-linear.json` 
+  yError=`jq -M '.[0] .yError' calibration-linear.json` 
 else
   slope=1000
   yIntercept=0
@@ -243,11 +245,11 @@ cat entry.json | jq ".[0].direction = \"$direction\"" > entry-xdrip.json
 
 
 if [ ! -f "/var/log/openaps/g5.csv" ]; then
-  echo "datetime,unfiltered,filtered,glucoseg5,glucose,direction,calibratedBG,slope,yIntercept" > /var/log/openaps/g5.csv
+  echo "datetime,unfiltered,filtered,glucoseg5,glucose,direction,calibratedBG,slope,yIntercept,slopeError,yError" > /var/log/openaps/g5.csv
 fi
 
 
-echo "${datetime},${unfiltered},${filtered},${glucoseg5},${glucose},${direction},${calibratedBG},${slope},${yIntercept}" >> /var/log/openaps/g5.csv
+echo "${datetime},${unfiltered},${filtered},${glucoseg5},${glucose},${direction},${calibratedBG},${slope},${yIntercept},${slopeError},${yError}" >> /var/log/openaps/g5.csv
 
 echo "Posting glucose record to xdripAPS"
 ./post-xdripAPS.sh ./entry-xdrip.json

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# 
 glucoseType='.[0].unfiltered'
 
 cd /root/src/xdrip-js-logger

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -12,12 +12,12 @@ CALIBRATION_STORAGE="calibration.json"
 # remove old calibration storage when sensor change occurs
 # calibrate after 15 minutes of sensor change time entered in NS
 
-curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "15 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
+#curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "15 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
 
-if [ $? == 0 ]; then
-  echo "sensor change - removing calibration"
-  rm $CALIBRATION_STORAGE
-fi
+#if [ $? == 0 ]; then
+#  echo "sensor change - removing calibration"
+#  rm $CALIBRATION_STORAGE
+#fi
 
 if [ -e "./entry.json" ] ; then
   lastGlucose=$(cat ./entry.json | jq -M $glucoseType)
@@ -47,7 +47,7 @@ cat ./entry.json
 #        scaling unfiltered directly, i.e., use a variable, as there values
 #        should be passed to NS unaltered. This will become more important
 #        when we also send it a cal record...)
-calSlope=750
+calSlope=950
 scaled=$(cat ./entry.json | jq -M $glucoseType)
 scaled=$(($scaled * 1000 / $calSlope))
 tmp=$(mktemp)

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -72,7 +72,7 @@ else
   # remove old calibration storage when sensor change occurs
   # calibrate after 15 minutes of sensor change time entered in NS
   curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "15 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
-  if [ $? == 0 ]; 
+  if [ $? == 0 ]; then
     rm $CALIBRATION_STORAGE
   fi
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -207,3 +207,4 @@ bt-device -r $id
 echo "Finished xdrip-get-entries.sh"
 date
 echo
+

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -33,25 +33,24 @@ cat ./entry.json
 glucose=$(cat ./entry.json | jq -M $glucoseType)
 echo
 
-if [ "${glucose}" == "" ] ; then
+if [ -z "${glucose}" ] ; then
   echo "Invalid response from g5 transmitter"
   ls -al ./entry.json
   cat ./entry.json
   rm ./entry.json
 else
 
-  dg=`expr $glucose - $lastGlucose`
+  dg=$(bc -l <<< "$glucose - $lastGlucose")
 
   # begin try out averaging last two entries ...
   da=${dg}
-  if [ ${da} -lt 0 ]; then
-    da=`expr 0 - $da`
+  if [ -n ${da} -a $(bc <<< "${da} < 0") -eq 1 ]; then
+    da=$(bc <<< "0 - $da")
   fi
-  if [ ${da} -lt 45 -a ${da} -gt 6 ]; then
+  if (( $(bc <<< "(${da} < 45) && (${da} > 6)") )); then
      echo "Before Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=${glucose}"
-     glucose=`expr $glucose + $lastGlucose`
-     glucose=`expr $glucose / 2`
-     dg=`expr $glucose - $lastGlucose`
+     glucose=$(bc -l <<< "($glucose + $lastGlucose)/2")
+     dg=$(bc -l <<< "$glucose - $lastGlucose")
      echo "After Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=${glucose}"
   fi
   # end average last two entries if noise  code
@@ -83,7 +82,7 @@ else
   # TBD: meter BG from pumphistory doesn't support mmol yet - has no units...
   echo "meterbg from pumphistory: $meterbg" 
 
-  if [ "$meterbg" == "" ]; then
+  if [ -z $meterbg ]; then
     # look for a bg check from NS (& test NS record for local time or UTC)
     curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null >> $METERBG_NS_RAW
     isUTC=$(jq ".[0].created_at[-1:]" $METERBG_NS_RAW)
@@ -95,29 +94,25 @@ else
       fi
     fi
 
-    meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
-    meterbg=$(cat $METERBG_NS_RAW | jq -M '.[0] | .glucose')
-    meterbg="${meterbg%\"}"
-    meterbg="${meterbg#\"}"
+    meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units' | tr -d '"')
+    meterbg=$(cat $METERBG_NS_RAW | jq -M '.[0] | .glucose' | tr -d '"')
     if [ "$meterbgunits" == "mmol" ]; then
-      meterbg=$(echo $meterbg "*18" | bc)
+      meterbg=$(bc -l <<< "$meterbg *18")
     fi
     echo "meterbg from nightscout: $meterbg" 
   fi
 
-  if [ "$meterbg" == "null" ]; then
-    :
-  else
-    if [ $meterbg -lt 400 -a $meterbg -gt 40 ]; then
+  if [ -n "$meterbg" ]; then
+    if (( bc -l <<< "($meterbg < 400) && ($meterbg > 40)" )); then
       calibrationBg=$meterbg
-      if [ "$lastPostCal" != "" ]; then
-        if [ $lastPostCal -lt 400 -a $lastPostCal -gt 40 ]; then
+      if [ -n "$lastPostCal" ]; then
+        if (( bc <<< "($lastPostCal < 400) && ($lastPostCal > 40)" )); then
           calibrationBg=$((($meterbg + $lastPostCal) / 2))
         fi
       fi
-      calibration=`expr $calibrationBg - $glucose`
+      calibration="$(bc -l <<< "$calibrationBg - $glucose")"
       echo "calibration=$calibration, meterbg=$meterbg, lastPostCal=$lastPostCal, calibrationBg=$calibrationBg, glucose=$glucose"
-      if [ $calibration -lt 60 -a $calibration -gt -80 ]; then
+      if (( bc -l <<< "($calibration < 60) && ($calibration > -80)" )); then
         # another safety check, but this is a good calibration
         echo "[{\"calibration\":${calibration}}]" > $CALIBRATION_STORAGE
         cp $METERBG_NS_RAW meterbg-ns-backup.json
@@ -127,7 +122,7 @@ else
 
   if [ -e $CALIBRATION_STORAGE ]; then
     calibration=$(cat $CALIBRATION_STORAGE | jq -M '.[0] | .calibration')
-    calibratedglucose=`expr $glucose + $calibration`
+    calibratedglucose=$(bc -l <<< "$glucose + $calibration")
     echo "After calibration calibratedglucose =$calibratedglucose"
   else
     echo "No valid calibration yet - exiting"
@@ -150,19 +145,19 @@ else
   direction='NONE'
   echo "Valid response from g5 transmitter"
 
-  if [ ${dg} -lt -10 ]; then
+  if (( $(bc <<< "${dg} < -10") )); then
      direction='DoubleDown'
-  elif [ ${dg} -lt -7 ]; then 
+  elif (( $(bc <<< "${dg} < -7") )); then
      direction='SingleDown'
-  elif [ ${dg} -lt -3 ]; then
+  elif (( $(bc <<< "${dg} < -3") )); then
      direction='FortyFiveDown'
-  elif [ ${dg} -lt 3 ]; then
+  elif (( $(bc <<< "${dg} < 3") )); then
      direction='Flat'
-  elif [ ${dg} -lt 7 ]; then
+  elif (( $(bc <<< "${dg} < 7") )); then
      direction='FortyFiveUp'
-  elif [ ${dg} -lt 10 ]; then
+  elif (( $(bc <<< "${dg} < 10") )); then
      direction='SingleUp'
-  elif [ ${dg} -lt 50 ]; then
+  elif (( $(bc <<< "${dg} < 50") )); then
      direction='DoubleUp'
   fi
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -91,7 +91,7 @@ else
 
     if [[ $createdAt == *"Z"* ]]; then
        echo "meterbg within 7 minutes using UTC time comparison."       
-    elif   
+    else   
       if [ "$createdAt" != "NULL" -a "$createdAt" != "" ]; then
         curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
         echo "meterbg within 7 minutes using non-UTC time comparison."

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -79,7 +79,6 @@ fi
 # capture raw values for use and for log to csv file 
 unfiltered=$(cat ./entry.json | jq -M '.[0].unfiltered')
 filtered=$(cat ./entry.json | jq -M '.[0].filtered')
-glucoseg5=$(cat ./entry.json | jq -M '.[0].glucose')
 datetime=$(date +"%Y-%m-%d %H:%M")
 if [ "glucoseType" == "filtered" ]; then
   raw=$filtered
@@ -245,11 +244,11 @@ cat entry.json | jq ".[0].direction = \"$direction\"" > entry-xdrip.json
 
 
 if [ ! -f "/var/log/openaps/g5.csv" ]; then
-  echo "datetime,unfiltered,filtered,glucoseg5,glucose,direction,calibratedBG,slope,yIntercept,slopeError,yError" > /var/log/openaps/g5.csv
+  echo "datetime,unfiltered,filtered,glucose,trend,calibratedBG,slope,yIntercept,slopeError,yError" > /var/log/openaps/g5.csv
 fi
 
 
-echo "${datetime},${unfiltered},${filtered},${glucoseg5},${glucose},${direction},${calibratedBG},${slope},${yIntercept},${slopeError},${yError}" >> /var/log/openaps/g5.csv
+echo "${datetime},${unfiltered},${filtered},${glucose},${direction},${calibratedBG},${slope},${yIntercept},${slopeError},${yError}" >> /var/log/openaps/g5.csv
 
 echo "Posting glucose record to xdripAPS"
 ./post-xdripAPS.sh ./entry-xdrip.json

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -11,7 +11,6 @@ CALIBRATION_STORAGE="calibration.json"
 
 # remove old calibration storage when sensor change occurs
 # calibrate after 15 minutes of sensor change time entered in NS
-
 # disable this feature for now. It isn't recreating the calibration file after sensor insert and BG check
 #
 #curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "15 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
@@ -46,22 +45,12 @@ echo "after xdrip-js bg record below ..."
 cat ./entry.json
 
 # re-scale unfiltered from /1000 to /$calSlope
-# (NOTE: We should also cleanup this script to avoid
-#        scaling unfiltered directly, i.e., use a variable, as there values
-#        should be passed to NS unaltered. This will become more important
-#        when we also send it a cal record...)
 
 scaled=$(cat ./entry.json | jq -M $glucoseType)
 scaled=$(($scaled / $calSlope))
 tmp=$(mktemp)
-#jq "$glucoseType = $scaled" entry.json > "$tmp" && mv "$tmp" entry.json
-#echo "after unfiltered-scale bg record below ..."
-#cat ./entry.json
-
-#glucose=$(cat ./entry.json | jq -M $glucoseType)
 glucose=$scaled
-
-echo
+echo "scaled glucose=$glucose, scale=$calSlope"
 
 if [ -z "${glucose}" ] ; then
   echo "Invalid response from g5 transmitter"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -328,7 +328,7 @@ else
 fi
 
 echo "Posting blood glucose record(s) to NightScout"
-./post-ns.sh ./entry-ns.json && (echo; echo "Upload to NightScout of xdrip entry worked ... removing ./entry-backfill.json"; rm -f ./entry-backfill.json) || (echo; echo "Upload to NS of xdrip entry did not work ... saving for upload when network is restored"; cp ./entry-ns.json ./entry-backfill.json)
+./post-ns.sh ./entry-ns.json && (echo; echo "Upload to NightScout of xdrip entry worked ... removing ./entry-backfill.json"; rm -f ./entry-backfill.json) || (echo; echo "Upload to NS of xdrip entry did not work ... saving for upload when network is restored ... Auth to NS may have failed; ensure you are using hashed API_SECRET in ~/.bash_profile"; cp ./entry-ns.json ./entry-backfill.json)
 echo
 
 bt-device -r $id

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -35,6 +35,8 @@ if [ $? == 0 ]; then
   cp $CAL_OUTPUT "${CAL_OUTPUT}.$(date +%Y%m%d-%H%M%S)"
   rm $CAL_INPUT
   rm $CAL_OUTPUT
+  echo "exiting"
+  exit
 fi
 
 glucoseType='.[0].unfiltered'
@@ -127,6 +129,10 @@ if [ -e $CAL_OUTPUT ]; then
 else
   slope=1000
   yIntercept=0
+  # exit until we have a valid calibration record
+  echo "no valid calibration record yet, exiting ..."
+  bt-device -r $id
+  exit
 fi
 
 calibratedBG=$(bc -l <<< "($unfiltered - $yIntercept)/$slope")
@@ -184,6 +190,7 @@ direction='NONE'
 # Begin trend calculation logic based on last 15 minutes glucose delta average
 if [ -z "$dg" ]; then
   direction="NONE"
+  echo "setting direction=NONE because dg is null, dg=$dg"
 else
   echo $dg > bgdelta-$(date +%Y%m%d-%H%M%S).dat
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -236,6 +236,7 @@ if [ $(bc <<< "$meterbg < 400") -eq 1  -a $(bc <<< "$meterbg > 40") -eq 1 ]; the
 
 
   predicted=$(bc -l <<< "($unfiltered-$yIntercept)/$slope")
+  predicted=$(bc <<< "($predicted/1)") # truncate
   echo "${datetime},${unfiltered},${filtered},${glucoseg5},${glucose},${calibratedglucose},${calSlope},${direction},${calibration},${calibrationBg},${predicted},${slope},${yIntercept}" >> /var/log/openaps/g5.csv
 
   echo "Posting glucose record to xdripAPS"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -97,7 +97,7 @@ else
   fi
 
   if [ -e $CALIBRATION_STORAGE ]; then
-    calibration=$(cat $CALIBRATION_STORAGE | jq -M '.[0] | .calibration')
+    calibration=$(cat $CALIBRATION_STORAGE | jq -M '.[0] | .calibration')thenjesus cross pendant
     calibratedglucose=`expr $glucose + $calibration`
     echo "After calibration calibratedglucose =$calibratedglucose"
   fi
@@ -130,7 +130,7 @@ else
   elif [ ${dg} -lt 10 ]; then
      direction='SingleUp'
   elif [ ${dg} -lt 50 ]; then
-     direction='DoubleUp'jesus cross pendant
+     direction='DoubleUp'
   fi
 
   echo "Gluc=${glucose}, last=${lastGlucose}, diff=${dg}, dir=${direction}"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -72,7 +72,7 @@ else
   METERBG_NS_RAW="meterbg_ns_raw.json"
   CALIBRATION_STORAGE="calibration.json"
 
-  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "5 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "6 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
 
   meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
   meterbg=$(cat $METERBG_NS_RAW | jq -M '.[0] | .glucose')
@@ -119,7 +119,7 @@ else
 
   if [ ${dg} -lt -10 ]; then
      direction='DoubleDown'
-  elif [ ${dg} -lt -7 ]; then
+  elif [ ${dg} -lt -7 ]; thenjesus cross pendant
      direction='SingleDown'
   elif [ ${dg} -lt -3 ]; then
      direction='FortyFiveDown'
@@ -130,7 +130,7 @@ else
   elif [ ${dg} -lt 10 ]; then
      direction='SingleUp'
   elif [ ${dg} -lt 50 ]; then
-     direction='DoubleUp'
+     direction='DoubleUp'jesus cross pendant
   fi
 
   echo "Gluc=${glucose}, last=${lastGlucose}, diff=${dg}, dir=${direction}"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -72,7 +72,7 @@ else
   METERBG_NS_RAW="meterbg_ns_raw.json"
   CALIBRATION_STORAGE="calibration.json"
 
-  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "5 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
 
   meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
   meterbg=$(cat $METERBG_NS_RAW | jq -M '.[0] | .glucose')

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -12,8 +12,8 @@ CAL_INPUT="./calibrations.csv"
 CAL_OUTPUT="./calibration-linear.json"
 # check UTC to begin with and use UTC flag for any curls
 NS_RAW="testUTC.json"
-curl --compressed -m 30 "${NIGHTSCOUT_HOST}/api/v1/entries.json?find\[dateString\]\[\$gte\]=$(date -d "10 minutes ago" -Iminutes -u)" 2>/dev/null  > $NS_RAW  
-createdAt=$(jq ".[0].dateString" $NS_RAW)
+curl --compressed -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?count=1&find\[created_at\]\[\$gte\]=$(date -d "6000 minutes ago" -Iminutes -u)" 2>/dev/null  > $NS_RAW  
+createdAt=$(jq ".[0].created_at" $NS_RAW)
 if [[ $createdAt == *"Z"* ]]; then
   UTC=" -u "
   echo "NS is using UTC $UTC"       

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -161,7 +161,8 @@ if [ "$calibrationType" = "SinglePoint" ]; then
   if [ $(bc <<< "$c > 69") -eq 1 -a $(bc <<< "$c < 85") -eq 1 ]; then
     echo "SinglePoint calibration calculating corrective intercept"
     echo "Before CI, BG=$c"
-    calibratedBG=$(bc <<< "$c - (-0.16667 * ${c}^2 + 25.6667 * ${c} - 977.5)")
+    calibratedBG=$(bc -l <<< "$c - (-0.16667 * ${c}^2 + 25.6667 * ${c} - 977.5)")
+    calibratedBG=$(bc <<< "($calibratedBG / 1)") # truncate
     echo "After CI, BG=$calibratedBG"
   else
     echo "bg not in range [70-84]"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -86,21 +86,15 @@ else
   if [ -z $meterbg ]; then
     curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "12 hours ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
     createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
-    echo createdAt=${createdAt}
 
     if [[ $createdAt == *"Z"* ]]; then
-      echo "NS is UTC"
       curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
     else
-      echo "NS is not UTC"
       curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
     fi
     
-#curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-
     meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
     meterbg=`jq -M '.[0] .glucose' $METERBG_NS_RAW`
-    #meterbg=$(cat $METERBG_NS_RAW | jq -M '.[0] | .glucose')
     meterbg="${meterbg%\"}"
     meterbg="${meterbg#\"}"
     if [ "$meterbgunits" == "mmol" ]; then
@@ -124,43 +118,7 @@ else
         cp $METERBG_NS_RAW meterbg-ns-backup.json
       fi
     fi
-  ficurl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "100 hours ago" -
-Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-
-
-createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
-echo createdAt=${createdAt}
-
-if [[ $createdAt == *"Z"* ]]; then
-  echo "UTC"
-  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "1 hours ago" -
-Ihours)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-
-else
-  echo "Not UTC"
-  curl -m 30 "${ns_url}/api/v1/treatments.jsoncurl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "100 hours ago" -
-Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-
-
-createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
-echo createdAt=${createdAt}
-
-if [[ $createdAt == *"Z"* ]]; then
-  echo "UTC"
-  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "1 hours ago" -
-Ihours)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-
-else
-  echo "Not UTC"
-  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "1 hours ago" -
-Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-
-fi
-?find\[created_at\]\[\$gte\]=$(date -d "1 hours ago" -
-Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-
-fi
-
+  fi
 
   if [ -e $CALIBRATION_STORAGE ]; then
     calibration=$(cat $CALIBRATION_STORAGE | jq -M '.[0] | .calibration')

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -47,7 +47,7 @@ cat ./entry.json
 #        scaling unfiltered directly, i.e., use a variable, as there values
 #        should be passed to NS unaltered. This will become more important
 #        when we also send it a cal record...)
-calSlope=950
+calSlope=850
 scaled=$(cat ./entry.json | jq -M $glucoseType)
 scaled=$(($scaled / $calSlope))
 tmp=$(mktemp)
@@ -136,7 +136,7 @@ else
       fi
       calibration="$(bc <<< "$calibrationBg - $glucose")"
       echo "calibration=$calibration, meterbg=$meterbg, lastPostCal=$lastPostCal, calibrationBg=$calibrationBg, glucose=$glucose"
-      if [ "$calibration" -lt "60" -a "$calibration" -gt "-80" ]; then
+      if [ "$calibration" -lt "60" -a "$calibration" -gt "-150" ]; then
         # another safety check, but this is a good calibration
         echo "[{\"calibration\":${calibration}}]" > $CALIBRATION_STORAGE
         cat $CALIBRATION_STORAGE
@@ -162,8 +162,8 @@ else
     exit
   fi
 
-  if [ "$dg" -gt "50" -o "$dg" -lt "-50" ]; then
-    echo "Change $dg out of range [-50,50] - exiting"
+  if [ "$dg" -gt "50" -o "$dg" -lt "-150" ]; then
+    echo "Change $dg out of range [50,-150] - exiting"
     bt-device -r $id
     exit
   fi

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -119,7 +119,7 @@ else
 
   if [ ${dg} -lt -10 ]; then
      direction='DoubleDown'
-  elif [ ${dg} -lt -7 ]; thenjesus cross pendant
+  elif [ ${dg} -lt -7 ]; 
      direction='SingleDown'
   elif [ ${dg} -lt -3 ]; then
      direction='FortyFiveDown'

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -262,11 +262,11 @@ cat entry.json | jq ".[0].direction = \"$direction\"" > entry-xdrip.json
 
 
 if [ ! -f "/var/log/openaps/g5.csv" ]; then
-  echo "datetime,unfiltered,filtered,trend,calibratedBG,slope,yIntercept,slopeError,yError,rSquared" > /var/log/openaps/g5.csv
+  echo "datetime,unfiltered,filtered,trend,calibratedBG,meterbg,slope,yIntercept,slopeError,yError,rSquared" > /var/log/openaps/g5.csv
 fi
 
 
-echo "${datetime},${unfiltered},${filtered},${direction},${calibratedBG},${slope},${yIntercept},${slopeError},${yError},${rSquared}" >> /var/log/openaps/g5.csv
+echo "${datetime},${unfiltered},${filtered},${direction},${calibratedBG},${meterbg},${slope},${yIntercept},${slopeError},${yError},${rSquared}" >> /var/log/openaps/g5.csv
 
 echo "Posting glucose record to xdripAPS"
 ./post-xdripAPS.sh ./entry-xdrip.json

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -27,12 +27,12 @@ function ClearCalibrationCache()
 # check UTC to begin with and use UTC flag for any curls
 curl --compressed -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?count=1&find\[created_at\]\[\$gte\]=$(date -d "6000 minutes ago" -Iminutes -u)" 2>/dev/null  > ./testUTC.json  
 createdAt=$(jq ".[0].created_at" ./testUTC.json)
-if [[ $createdAt == *"Z"* ]]; then
-  UTC=" -u "
-  echo "NS is using UTC $UTC"       
-else
+if [[ ! ($createdAt == *"Z"*) ]]; then
   UTC=""
   echo "NS is not using UTC"       
+else
+  UTC=" -u "
+  echo "NS is using UTC $UTC"      
 fi
 
 # remove old calibration storage when sensor change occurs

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+
 glucoseType='.[0].unfiltered'
 
 cd /root/src/xdrip-js-logger

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -46,19 +46,22 @@ function ClearCalibrationCache()
   fi
 }
 
+UTC=" -u "
 # check UTC to begin with and use UTC flag for any curls
 curl --compressed -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?count=1&find\[created_at\]\[\$gte\]=$(date -d "2400 hours ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null  > ./testUTC.json  
 createdAt=$(jq ".[0].created_at" ./testUTC.json)
-if [ "$createdAt" == "" ]; then
-  echo "You must record a \"Sensor Insert\" in Nightscout before Logger will run" 
-  echo -e "exiting\n"
-  exit
-elif [[ $createdAt == *"Z"* ]]; then
-  UTC=" -u "
-  echo "NS is using UTC $UTC"      
-else
-  UTC=""
-  echo "NS is not using UTC $UTC"      
+if [ $? == 0 ]; then
+  if [ $"$createdAt" == "" ]; then
+    echo "You must record a \"Sensor Insert\" in Nightscout before Logger will run" 
+    echo -e "exiting\n"
+    exit
+  elif [[ $createdAt == *"Z"* ]]; then
+    UTC=" -u "
+    echo "NS is using UTC $UTC"      
+  else
+    UTC=""
+    echo "NS is not using UTC $UTC"      
+  fi
 fi
 
 # remove old calibration storage when sensor change occurs

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -116,7 +116,7 @@ else
     meterbg="${meterbg%\"}"
     meterbg="${meterbg#\"}"
     if [ "$meterbgunits" == "mmol" ]; then
-      meterbg=$(bc <<< "$meterbg *18")
+      meterbg=$(bc <<< "($meterbg *18)/1")
     fi
     echo "meterbg from nightscout: $meterbg"
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -253,11 +253,11 @@ cat entry.json | jq ".[0].direction = \"$direction\"" > entry-xdrip.json
 
 
 if [ ! -f "/var/log/openaps/g5.csv" ]; then
-  echo "datetime,unfiltered,filtered,glucose,trend,calibratedBG,slope,yIntercept,slopeError,yError" > /var/log/openaps/g5.csv
+  echo "datetime,unfiltered,filtered,trend,calibratedBG,slope,yIntercept,slopeError,yError" > /var/log/openaps/g5.csv
 fi
 
 
-echo "${datetime},${unfiltered},${filtered},${glucose},${direction},${calibratedBG},${slope},${yIntercept},${slopeError},${yError}" >> /var/log/openaps/g5.csv
+echo "${datetime},${unfiltered},${filtered},${direction},${calibratedBG},${slope},${yIntercept},${slopeError},${yError}" >> /var/log/openaps/g5.csv
 
 echo "Posting glucose record to xdripAPS"
 ./post-xdripAPS.sh ./entry-xdrip.json

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -3,6 +3,7 @@
 glucoseType="unfiltered"
 
 cd /root/src/xdrip-js-logger
+mkdir -p old-calibrations
 
 echo "Starting xdrip-get-entries.sh"
 date
@@ -31,14 +32,14 @@ fi
 function ClearCalibrationInput()
 {
   if [ -e ./calibrations.csv ]; then
-    cp ./calibrations.csv "./calibrations.csv.$(date +%Y%m%d-%H%M%S)" 
+    cp ./calibrations.csv "./old-calibrations/calibrations.csv.$(date +%Y%m%d-%H%M%S)" 
     rm ./calibrations.csv
   fi
 }
 
 function ClearCalibrationCache()
 {
-  local cache="./calibration-linear.json"
+  local cache="./old-calibrations/calibration-linear.json"
   if [ -e $cache ]; then
     cp $cache "${cache}.$(date +%Y%m%d-%H%M%S)" 
     rm $cache 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
-# requirements
-#   bt-device --> bluez-tools
-#      sudo apt-get install bluez-tools
-#   xdrip-js
-#
+
+glucoseType='.[0].unfiltered'
 
 cd /root/src/xdrip-js-logger
 
@@ -12,7 +9,7 @@ date
 
 
 if [ -e "./entry.json" ] ; then
-  lastGlucose=$(cat ./entry.json | jq -M '.[0].unfiltered')
+  lastGlucose=$(cat ./entry.json | jq -M $glucoseType)
   lastUnfiltered=$(cat ./entry.json | jq -M '.[0].unfiltered')
   lastAfter=$(date -u -d "5 minutes ago" -Iminutes)
   lastPostStr="'.[0] | select(.dateString > \"$lastAfter\") | .glucose'"
@@ -25,17 +22,15 @@ transmitter=$1
 
 id2=$(echo "${transmitter: -2}")
 id="Dexcom${id2}"
-echo "Removing existing Dexcom bluetooth connection = ${id}"
+echo "Removing existing Dexcom bluetooth connection = ${id}"'.[0].unfiltered'
 bt-device -r $id
 
 echo "Calling xdrip-js ... node logger $transmitter"
 DEBUG=smp,transmitter,bluetooth-manager timeout 360s node logger $transmitter
-#DEBUG=transmitter,bluetooth-manager node logger 410BFE
 echo "after xdrip-js bg record below ..."
-
 cat ./entry.json
 
-glucose=$(cat ./entry.json | jq -M '.[0].unfiltered')
+glucose=$(cat ./entry.json | jq -M $glucoseType)
 echo
 
 if [ "${glucose}" == "" ] ; then
@@ -65,9 +60,7 @@ else
   unfiltered=$(cat ./entry.json | jq -M '.[0].unfiltered')
   filtered=$(cat ./entry.json | jq -M '.[0].filtered')
   glucoseg5=$(cat ./entry.json | jq -M '.[0].glucose')
-#  logdate=$(cat ./entry.json | jq -M '.[0].dateString')
   datetime=$(date +"%Y-%m-%d %H:%M")
-
   # end log to csv file logic for g5 outputs
 
   # begin calibration logic - look for calibration from NS, use existing calibration or none
@@ -76,17 +69,10 @@ else
   METERBG_NS_RAW="meterbg_ns_raw.json"
   CALIBRATION_STORAGE="calibration.json"
 
-
   # remove old calibration storage when sensor change occurs
   # calibrate after 15 minutes of sensor change time entered in NS
   curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "15 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
-  if [ $? == 0 ]; thenEric,
-
-I got sick over the weekend. Thought it may be better by this morning but it got worse overnight. 
-Sorry I’m going to miss SLT and the mentee dinner.
-
-Thanks,
-
+  if [ $? == 0 ]; 
     rm $CALIBRATION_STORAGE
   fi
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -84,7 +84,7 @@ else
   echo "meterbg from pumphistory: $meterbg"
 
   if [ -z $meterbg ]; then
-    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "100 hours ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "12 hours ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
     createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
     echo createdAt=${createdAt}
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -42,14 +42,13 @@ echo "after xdrip-js bg record below ..."
 cat ./entry.json
 
 # re-scale unfiltered from /1000 to /$calSlope
-# (NOTE: ideally xdrip-js should be changed to not scale down unfiltered and
-#        filtered by 1000, and we should also cleanup this script to avoid
+# (NOTE: We should also cleanup this script to avoid
 #        scaling unfiltered directly, i.e., use a variable, as there values
 #        should be passed to NS unaltered. This will become more important
 #        when we also send it a cal record...)
 calSlope=950
 scaled=$(cat ./entry.json | jq -M $glucoseType)
-scaled=$(($scaled * 1000 / $calSlope))
+scaled=$(($scaled / $calSlope))
 tmp=$(mktemp)
 jq "$glucoseType = $scaled" entry.json > "$tmp" && mv "$tmp" entry.json
 echo "after unfiltered-scale bg record below ..."

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -51,6 +51,8 @@ if [ -z "${glucose}" ] ; then
   echo "Invalid response from g5 transmitter"
   ls -al ./entry.json
   rm ./entry.json
+  bt-device -r $id
+  exit
 fi
 
 # capture raw values for use and for log to csv file 
@@ -75,6 +77,8 @@ echo "meterbg from pumphistory: $meterbg"
 
 if [ -z $meterbg ]; then
   curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+  #createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
+  meterbgid=$(jq ".[0]._id" $METERBG_NS_RAW)
   createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
 
   if [[ $createdAt == *"Z"* ]]; then
@@ -126,122 +130,114 @@ fi
 
 glucose=$calibratedBG
 
-if [ -z "${glucose}" ] ; then
-  echo "Invalid response from g5 transmitter"
-  ls -al ./entry.json
-  cat ./entry.json
-  rm ./entry.json
+if [ -z $lastGlucose -o $(bc <<< "$lastGlucose < 40") -eq 1] ; then
+  dg=0
 else
-  echo "Valid response from g5 transmitter"
-  if [ -z $lastGlucose -o $(bc <<< "$lastGlucose < 40") -eq 1] ; then
-    dg=0
-  else
-    dg=$(bc <<< "$glucose - $lastGlucose")
-  fi
+  dg=$(bc <<< "$glucose - $lastGlucose")
+fi
 
-  # begin try out averaging last two entries ...
-  da=$dg
-  if [ -n $da -a $(bc <<< "$da < 0") -eq 1 ]; then
-    da=$(bc <<< "0 - $da")
-  fi
-  if [ "$da" -lt "45" -a "$da" -gt "15" ]; then
-   echo "Before Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=$glucose"
-   glucose=$(bc <<< "($glucose + $lastGlucose)/2")
-   dg=$(bc <<< "$glucose - $lastGlucose")
-   echo "After average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=${glucose}"
-  fi
-  # end average last two entries if noise  code
+# begin try out averaging last two entries ...
+da=$dg
+if [ -n $da -a $(bc <<< "$da < 0") -eq 1 ]; then
+  da=$(bc <<< "0 - $da")
+fi
+if [ "$da" -lt "45" -a "$da" -gt "15" ]; then
+ echo "Before Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=$glucose"
+ glucose=$(bc <<< "($glucose + $lastGlucose)/2")
+ dg=$(bc <<< "$glucose - $lastGlucose")
+ echo "After average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=${glucose}"
+fi
+# end average last two entries if noise  code
 
 
-  if [ $(bc <<< "$dg > 50") -eq 1 -o $(bc <<< "$dg < -50") -eq 1 ]; then
-    echo "Change $dg out of range [50,-50] - exiting"
-    bt-device -r $id
-    exit
-  fi
+if [ $(bc <<< "$dg > 50") -eq 1 -o $(bc <<< "$dg < -50") -eq 1 ]; then
+  echo "Change $dg out of range [50,-50] - exiting"
+  bt-device -r $id
+  exit
+fi
 
-   cp entry.json entry-before-calibration.json
+cp entry.json entry-before-calibration.json
 
-   tmp=$(mktemp)
-   jq ".[0].glucose = $calibratedBG" entry.json > "$tmp" && mv "$tmp" entry.json
+tmp=$(mktemp)
+jq ".[0].glucose = $calibratedBG" entry.json > "$tmp" && mv "$tmp" entry.json
 
-   tmp=$(mktemp)
-   jq ".[0].sgv = $calibratedBG" entry.json > "$tmp" && mv "$tmp" entry.json
+tmp=$(mktemp)
+jq ".[0].sgv = $calibratedBG" entry.json > "$tmp" && mv "$tmp" entry.json
 
-   tmp=$(mktemp)
-   jq ".[0].device = \"${transmitter}\"" entry.json > "$tmp" && mv "$tmp" entry.json
-  # end calibration logic
+tmp=$(mktemp)
+jq ".[0].device = \"${transmitter}\"" entry.json > "$tmp" && mv "$tmp" entry.json
+# end calibration logic
 
-  direction='NONE'
+direction='NONE'
 
-  # Begin trend calculation logic based on last 15 minutes glucose delta average
-  if [ -z "$dg" ]; then
-    direction="NONE"
-  else
-    echo $dg > bgdelta-$(date +%Y%m%d-%H%M%S).dat
+# Begin trend calculation logic based on last 15 minutes glucose delta average
+if [ -z "$dg" ]; then
+  direction="NONE"
+else
+  echo $dg > bgdelta-$(date +%Y%m%d-%H%M%S).dat
 
-       # first delete any delta's > 15 minutes
-    find . -name 'bgdelta*.dat' -mmin +15 -delete
-    usedRecords=0
-    totalDelta=0
-    for i in ./bgdelta*.dat; do
-      usedRecords=$(bc <<< "$usedRecords + 1")
-      currentDelta=`cat $i`
-      totalDelta=$(bc <<< "$totalDelta + $currentDelta")
-    done
+   # first delete any delta's > 15 minutes
+  find . -name 'bgdelta*.dat' -mmin +15 -delete
+  usedRecords=0
+  totalDelta=0
+  for i in ./bgdelta*.dat; do
+    usedRecords=$(bc <<< "$usedRecords + 1")
+    currentDelta=`cat $i`
+    totalDelta=$(bc <<< "$totalDelta + $currentDelta")
+  done
 
-    if [ $(bc <<< "$usedRecords > 0") -eq 1 ]; then
-      perMinuteAverageDelta=$(bc -l <<< "$totalDelta / (5 * $usedRecords)")
+  if [ $(bc <<< "$usedRecords > 0") -eq 1 ]; then
+    perMinuteAverageDelta=$(bc -l <<< "$totalDelta / (5 * $usedRecords)")
 
-      if (( $(bc <<< "$perMinuteAverageDelta > 3") )); then
-        direction='DoubleUp'
-      elif (( $(bc <<< "$perMinuteAverageDelta > 2") )); then
-        direction='SingleUp'
-      elif (( $(bc <<< "$perMinuteAverageDelta > 1") )); then
-        direction='FortyFiveUp'
-      elif (( $(bc <<< "$perMinuteAverageDelta < -3") )); then
-        direction='DoubleDown'
-      elif (( $(bc <<< "$perMinuteAverageDelta < -2") )); then
-        direction='SingleDown'
-      elif (( $(bc <<< "$perMinuteAverageDelta < -1") )); then
-        direction='FortyFiveDown'
-      else
-        direction='Flat'
-      fi
+    if (( $(bc <<< "$perMinuteAverageDelta > 3") )); then
+      direction='DoubleUp'
+    elif (( $(bc <<< "$perMinuteAverageDelta > 2") )); then
+      direction='SingleUp'
+    elif (( $(bc <<< "$perMinuteAverageDelta > 1") )); then
+      direction='FortyFiveUp'
+    elif (( $(bc <<< "$perMinuteAverageDelta < -3") )); then
+      direction='DoubleDown'
+    elif (( $(bc <<< "$perMinuteAverageDelta < -2") )); then
+      direction='SingleDown'
+    elif (( $(bc <<< "$perMinuteAverageDelta < -1") )); then
+      direction='FortyFiveDown'
+    else
+      direction='Flat'
     fi
   fi
-
-  echo "perMinuteAverageDelta=$perMinuteAverageDelta, totalDelta=$totalDelta, usedRecords=$usedRecords"
-  echo "Gluc=${glucose}, last=${lastGlucose}, diff=${dg}, dir=${direction}"
-
-
-  cat entry.json | jq ".[0].direction = \"$direction\"" > entry-xdrip.json
-
-
-  if [ ! -f "/var/log/openaps/g5.csv" ]; then
-    echo "datetime,unfiltered,filtered,glucoseg5,glucose,direction,calibratedBG,slope,yIntercept" > /var/log/openaps/g5.csv
-  fi
-
-
-  echo "${datetime},${unfiltered},${filtered},${glucoseg5},${glucose},${direction},${calibratedBG},${slope},${yIntercept}" >> /var/log/openaps/g5.csv
-
-  echo "Posting glucose record to xdripAPS"
-  ./post-xdripAPS.sh ./entry-xdrip.json
-
-  if [ -e "./entry-backfill.json" ] ; then
-    # In this case backfill records not yet sent to Nightscout
-
-    jq -s add ./entry-xdrip.json ./entry-backfill.json > ./entry-ns.json
-    cp ./entry-ns.json ./entry-backfill.json
-    echo "entry-backfill.json exists, so setting up for backfill"
-  else
-    echo "entry-backfill.json does not exist so no backfill"
-    cp ./entry-xdrip.json ./entry-ns.json
-  fi
-
-  echo "Posting blood glucose record(s) to NightScout"
-  ./post-ns.sh ./entry-ns.json && (echo; echo "Upload to NightScout of xdrip entry worked ... removing ./entry-backfill.json"; rm -f ./entry-backfill.json) || (echo; echo "Upload to NS of xdrip entry did not work ... saving for upload when network is restored"; cp ./entry-ns.json ./entry-backfill.json)
-  echo
 fi
+
+echo "perMinuteAverageDelta=$perMinuteAverageDelta, totalDelta=$totalDelta, usedRecords=$usedRecords"
+echo "Gluc=${glucose}, last=${lastGlucose}, diff=${dg}, dir=${direction}"
+
+
+cat entry.json | jq ".[0].direction = \"$direction\"" > entry-xdrip.json
+
+
+if [ ! -f "/var/log/openaps/g5.csv" ]; then
+  echo "datetime,unfiltered,filtered,glucoseg5,glucose,direction,calibratedBG,slope,yIntercept" > /var/log/openaps/g5.csv
+fi
+
+
+echo "${datetime},${unfiltered},${filtered},${glucoseg5},${glucose},${direction},${calibratedBG},${slope},${yIntercept}" >> /var/log/openaps/g5.csv
+
+echo "Posting glucose record to xdripAPS"
+./post-xdripAPS.sh ./entry-xdrip.json
+
+if [ -e "./entry-backfill.json" ] ; then
+  # In this case backfill records not yet sent to Nightscout
+
+  jq -s add ./entry-xdrip.json ./entry-backfill.json > ./entry-ns.json
+  cp ./entry-ns.json ./entry-backfill.json
+  echo "entry-backfill.json exists, so setting up for backfill"
+else
+  echo "entry-backfill.json does not exist so no backfill"
+  cp ./entry-xdrip.json ./entry-ns.json
+fi
+
+echo "Posting blood glucose record(s) to NightScout"
+./post-ns.sh ./entry-ns.json && (echo; echo "Upload to NightScout of xdrip entry worked ... removing ./entry-backfill.json"; rm -f ./entry-backfill.json) || (echo; echo "Upload to NS of xdrip entry did not work ... saving for upload when network is restored"; cp ./entry-ns.json ./entry-backfill.json)
+echo
 
 bt-device -r $id
 echo "Finished xdrip-get-entries.sh"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -43,11 +43,6 @@ fi
 if [ -e "./entry.json" ] ; then
   lastGlucose=$(cat ./entry.json | jq -M '.[0].glucose')
   echo "lastGlucose=$lastGlucose"
-  
-#  lastAfter=$(date -d "5 minutes ago" -Iminutes)
-#  lastPostStr="'.[0] | select(.dateString > \"$lastAfter\") | .glucose'"
-#  lastPostCal=$(cat ./entry.json | bash -c "jq -M $lastPostStr")
-#  echo lastAfter=$lastAfter, lastPostStr=$lastPostStr, lastPostCal=$lastPostCal
   mv ./entry.json ./last-entry.json
 else
   echo "prior entry.json not available, setting lastGlucose=0"
@@ -171,13 +166,10 @@ if [ -z $calibratedBG -o $(bc <<< "$calibratedBG > 400") -eq 1 -o $(bc <<< "$cal
   exit
 fi
 
-
-glucose=$calibratedBG
-
 if [ -z $lastGlucose -o $(bc <<< "$lastGlucose < 40") -eq 1 ] ; then
   dg=0
 else
-  dg=$(bc <<< "$glucose - $lastGlucose")
+  dg=$(bc <<< "$calibratedBG - $lastGlucose")
 fi
 echo "lastGlucose=$lastGlucose, dg=$dg"
 
@@ -187,10 +179,10 @@ if [ -n $da -a $(bc <<< "$da < 0") -eq 1 ]; then
   da=$(bc <<< "0 - $da")
 fi
 if [ "$da" -lt "45" -a "$da" -gt "15" ]; then
- echo "Before Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=$glucose"
- glucose=$(bc <<< "($glucose + $lastGlucose)/2")
- dg=$(bc <<< "$glucose - $lastGlucose")
- echo "After average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=${glucose}"
+ echo "Before Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, calibratedBG=$calibratedBG"
+ calibratedBG=$(bc <<< "($calibratedBG + $lastGlucose)/2")
+ dg=$(bc <<< "$calibratedBG - $lastGlucose")
+ echo "After average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, calibratedBG=${calibratedBG}"
 fi
 # end average last two entries if noise  code
 
@@ -254,7 +246,7 @@ else
 fi
 
 echo "perMinuteAverageDelta=$perMinuteAverageDelta, totalDelta=$totalDelta, usedRecords=$usedRecords"
-echo "Gluc=${glucose}, last=${lastGlucose}, diff=${dg}, dir=${direction}"
+echo "Gluc=${calibratedBG}, last=${lastGlucose}, diff=${dg}, dir=${direction}"
 
 
 cat entry.json | jq ".[0].direction = \"$direction\"" > entry-xdrip.json

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -130,6 +130,7 @@ if [ -e $CAL_OUTPUT ]; then
   slopeError=`jq -M '.[0] .slopeError' calibration-linear.json` 
   yError=`jq -M '.[0] .yError' calibration-linear.json` 
   calibrationType=`jq -M '.[0] .calibrationType' calibration-linear.json` 
+  rSquared=`jq -M '.[0] .rSquared' calibration-linear.json` 
 else
   # exit until we have a valid calibration record
   echo "no valid calibration record yet, exiting ..."
@@ -253,11 +254,11 @@ cat entry.json | jq ".[0].direction = \"$direction\"" > entry-xdrip.json
 
 
 if [ ! -f "/var/log/openaps/g5.csv" ]; then
-  echo "datetime,unfiltered,filtered,trend,calibratedBG,slope,yIntercept,slopeError,yError" > /var/log/openaps/g5.csv
+  echo "datetime,unfiltered,filtered,trend,calibratedBG,slope,yIntercept,slopeError,yError,rSquared" > /var/log/openaps/g5.csv
 fi
 
 
-echo "${datetime},${unfiltered},${filtered},${direction},${calibratedBG},${slope},${yIntercept},${slopeError},${yError}" >> /var/log/openaps/g5.csv
+echo "${datetime},${unfiltered},${filtered},${direction},${calibratedBG},${slope},${yIntercept},${slopeError},${yError},${rSquared}" >> /var/log/openaps/g5.csv
 
 echo "Posting glucose record to xdripAPS"
 ./post-xdripAPS.sh ./entry-xdrip.json

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -84,7 +84,7 @@ else
   echo "meterbg from pumphistory: $meterbg"
 
   if [ -z $meterbg ]; then
-    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
     createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
 
     if [[ $createdAt != *"Z"* ]]; then

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -243,7 +243,7 @@ fi
 # end average last two entries if noise  code
 
 
-if [ $(bc <<< "$dg > $maxDelta)" -eq 1 -o $(bc <<< "$dg < (0 - $maxDelta)" -eq 1 ]; then
+if [ $(bc <<< "$dg > $maxDelta") -eq 1 -o $(bc <<< "$dg < (0 - $maxDelta)") -eq 1 ]; then
   echo "Change $dg out of range [$maxDelta,-${maxDelta}] - exiting"
   bt-device -r $id
   exit

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -90,7 +90,12 @@ else
     createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
 
     if [[ $createdAt != *"Z"* ]]; then
-      curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+      if [ "$createdAt" != "NULL" -a "$createdAt" != "" ]; then
+        curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+        echo "meterbg within 7 minutes using non-UTC time comparison."
+      fi
+    elif [[ $createdAt == *"Z" ]];then
+        echo "meterbg within 7 minutes using UTC time comparison."       
     fi
     
     meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -27,13 +27,13 @@ function ClearCalibrationCache()
 # check UTC to begin with and use UTC flag for any curls
 curl --compressed -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?count=1&find\[created_at\]\[\$gte\]=$(date -d "6000 minutes ago" -Iminutes -u)" 2>/dev/null  > ./testUTC.json  
 createdAt=$(jq ".[0].created_at" ./testUTC.json)
-if [[ ! ($createdAt == *"Z"*) ]]; then
-  UTC=""
-  echo "NS is not using UTC"       
-else
+#if [[ ! ($createdAt == *"Z"*) ]]; then
+#  UTC=""
+#  echo "NS is not using UTC"       
+#else
   UTC=" -u "
   echo "NS is using UTC $UTC"      
-fi
+#fi
 
 # remove old calibration storage when sensor change occurs
 # calibrate after 15 minutes of sensor change time entered in NS

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -84,13 +84,11 @@ else
   echo "meterbg from pumphistory: $meterbg"
 
   if [ -z $meterbg ]; then
-    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "12 hours ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
     createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
 
-    if [[ $createdAt == *"Z"* ]]; then
+    if [[ $createdAt != *"Z"* ]]; then
       curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-    else
-      curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
     fi
     
     meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-
-glucoseType='.[0].unfiltered'
+# requirements
+#   bt-device --> bluez-tools
+#      sudo apt-get install bluez-tools
+#   xdrip-js
+#
 
 cd /root/src/xdrip-js-logger
 
@@ -9,12 +12,8 @@ date
 
 
 if [ -e "./entry.json" ] ; then
-  lastGlucose=$(cat ./entry.json | jq -M $glucoseType)
+  lastGlucose=$(cat ./entry.json | jq -M '.[0].unfiltered')
   lastUnfiltered=$(cat ./entry.json | jq -M '.[0].unfiltered')
-  lastAfter=$(date -u -d "5 minutes ago" -Iminutes)
-  lastPostStr="'.[0] | select(.dateString > \"$lastAfter\") | .glucose'"
-  lastPostCal=$(cat ./entry.json | bash -c "jq -M $lastPostStr")
-  #echo lastAfter=$lastAfter, lastPostStr=$lastPostStr, lastPostCal=$lastPostCal
   mv ./entry.json ./last-entry.json
 fi
 
@@ -26,11 +25,13 @@ echo "Removing existing Dexcom bluetooth connection = ${id}"
 bt-device -r $id
 
 echo "Calling xdrip-js ... node logger $transmitter"
-DEBUG=smp,transmitter,bluetooth-manager timeout 360s node logger $transmitter
+timeout 360s node logger $transmitter
+#DEBUG=transmitter,bluetooth-manager node logger 410BFE
 echo "after xdrip-js bg record below ..."
+
 cat ./entry.json
 
-glucose=$(cat ./entry.json | jq -M $glucoseType)
+glucose=$(cat ./entry.json | jq -M '.[0].unfiltered')
 echo
 
 if [ "${glucose}" == "" ] ; then
@@ -40,11 +41,7 @@ if [ "${glucose}" == "" ] ; then
   rm ./entry.json
 else
 
-  if [ "${lastGlucose}" == "" ] ; then
-    dg=0
-  else
-    dg=`expr $glucose - $lastGlucose`
-  fi
+  dg=`expr $glucose - $lastGlucose`
 
   # begin try out averaging last two entries ...
   da=${dg}
@@ -64,7 +61,9 @@ else
   unfiltered=$(cat ./entry.json | jq -M '.[0].unfiltered')
   filtered=$(cat ./entry.json | jq -M '.[0].filtered')
   glucoseg5=$(cat ./entry.json | jq -M '.[0].glucose')
+#  logdate=$(cat ./entry.json | jq -M '.[0].dateString')
   datetime=$(date +"%Y-%m-%d %H:%M")
+
   # end log to csv file logic for g5 outputs
 
   # begin calibration logic - look for calibration from NS, use existing calibration or none
@@ -73,55 +72,23 @@ else
   METERBG_NS_RAW="meterbg_ns_raw.json"
   CALIBRATION_STORAGE="calibration.json"
 
-  # remove old calibration storage when sensor change occurs
-  # calibrate after 15 minutes of sensor change time entered in NS
-  curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "15 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
-  if [ $? == 0 ]; then
-    rm $CALIBRATION_STORAGE
-  fi
+  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "6 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
 
-  # look for a bg check from pumphistory (direct from meter->openaps):
-  meterbgafter=$(date -d "7 minutes ago" -Iminutes)
-  meterjqstr="'.[] | select(._type == \"BGReceived\") | select(.timestamp > \"$meterbgafter\") | .amount'"
-  meterbg=$(bash -c "jq $meterjqstr ~/myopenaps/monitor/pumphistory-merged.json")
-  # TBD: meter BG from pumphistory doesn't support mmol yet - has no units...
-  echo "meterbg from pumphistory: $meterbg"
-
-  if [ "$meterbg" == "" ]; then
-    # look for a bg check from NS (& test NS record for local time or UTC)
-    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null >> $METERBG_NS_RAW
-    isUTC=$(jq ".[0].created_at[-1:]" $METERBG_NS_RAW)
-    if [ "$isUTC" != '"Z"' ]; then
-      curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-      isUTC=$(jq ".[0].created_at[-1:]" $METERBG_NS_RAW)
-      if [ "$isUTC" == '"Z"' ]; then
-        echo > $METERBG_NS_RAW
-      fi
-    fi
-
-    meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
-    meterbg=$(cat $METERBG_NS_RAW | jq -M '.[0] | .glucose')
-    meterbg="${meterbg%\"}"
-    meterbg="${meterbg#\"}"
-    if [ "$meterbgunits" == "mmol" ]; then
-      meterbg=$(echo $meterbg "*18" | bc)
-    fi
-    echo "meterbg from nightscout: $meterbg"
+  meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
+  meterbg=$(cat $METERBG_NS_RAW | jq -M '.[0] | .glucose')
+  meterbg="${meterbg%\"}"
+  meterbg="${meterbg#\"}"
+  if [ "$meterbgunits" == "mmol" ]; then
+    meterbg=$(echo $meterbg "*18" | bc)
   fi
 
   if [ "$meterbg" == "null" ]; then
     :
   else
     if [ $meterbg -lt 400 -a $meterbg -gt 40 ]; then
-      calibrationBg=$meterbg
-      if [ "$lastPostCal" != "" ]; then
-        if [ $lastPostCal -lt 400 -a $lastPostCal -gt 40 ]; then
-          calibrationBg=$((($meterbg + $lastPostCal) / 2))
-        fi
-      fi
-      calibration=`expr $calibrationBg - $glucose`
-      echo "calibration=$calibration, meterbg=$meterbg, lastPostCal=$lastPostCal, calibrationBg=$calibrationBg, glucose=$glucose"
-      if [ $calibration -lt 60 -a $calibration -gt -80 ]; then
+      calibration=`expr $meterbg - $glucose`
+      echo "calibration=$calibration, meterbg=$meterbg, glucose=$glucose"
+      if [ $calibration -lt 30 -a $calibration -gt -50 ]; then
         # another safety check, but this is a good calibration
         echo "[{\"calibration\":${calibration}}]" > $CALIBRATION_STORAGE
         cp $METERBG_NS_RAW meterbg-ns-backup.json
@@ -133,22 +100,6 @@ else
     calibration=$(cat $CALIBRATION_STORAGE | jq -M '.[0] | .calibration')
     calibratedglucose=`expr $glucose + $calibration`
     echo "After calibration calibratedglucose =$calibratedglucose"
-  else
-    echo "No valid calibration yet - exiting"
-    bt-device -r $id
-    exit
-  fi
-
-  if [ $calibratedglucose -gt 400 -o $calibratedglucose -lt 40 ]; then
-    echo "Glucose $calibratedglucose out of range [40,400] - exiting"
-    bt-device -r $id
-    exit
-  fi
-
-  if [ $dg -gt 50 -o $dg -lt -50 ]; then
-    echo "Change $dg out of range [-50,50] - exiting"
-    bt-device -r $id
-    exit
   fi
 
    cp entry.json entry-before-calibration.json
@@ -168,7 +119,7 @@ else
 
   if [ ${dg} -lt -10 ]; then
      direction='DoubleDown'
-  elif [ ${dg} -lt -7 ]; then
+  elif [ ${dg} -lt -7 ]; then 
      direction='SingleDown'
   elif [ ${dg} -lt -3 ]; then
      direction='FortyFiveDown'
@@ -207,7 +158,7 @@ else
   fi
 
   echo "Posting blood glucose record(s) to NightScout"
-  ./post-ns.sh ./entry-ns.json && (echo; echo "Upload to NightScout of xdrip entry worked ... removing ./entry-backfill.json"; rm -f ./entry-backfill.json) || (echo; echo "Upload to NS of xdrip entry did not work ... saving for upload when network is restored"; cp ./entry-ns.json ./entry-backfill.json)
+  ./post-ns.sh ./entry-ns.json && (echo; echo "Upload to NightScout of xdrip entry worked ... removing ./entry-backfill.json"; rm ./entry-backfill.json) || (echo; echo "Upload to NS of xdrip entry did not work ... saving for upload when network is restored"; cp ./entry-ns.json ./entry-backfill.json)
   echo
 fi
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -207,4 +207,3 @@ bt-device -r $id
 echo "Finished xdrip-get-entries.sh"
 date
 echo
-

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -49,6 +49,9 @@ if [ -e "./entry.json" ] ; then
 #  lastPostCal=$(cat ./entry.json | bash -c "jq -M $lastPostStr")
 #  echo lastAfter=$lastAfter, lastPostStr=$lastPostStr, lastPostCal=$lastPostCal
   mv ./entry.json ./last-entry.json
+else
+  echo "prior entry.json not available, setting lastGlucose=0"
+  lastGlucose=0
 fi
 
 transmitter=$1

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -11,14 +11,14 @@ date
 if [ "$API_SECRET" = "" ]; then
    echo "API_SECRET environment variable is not set"
    echo -e "Make sure the two lines below are in your ~/.bash_profile as follows:\n"
-   echo "API_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx # where xxxx is your hased NS API_SECRET"
+   echo "API_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx # where xxxx is your hashed NS API_SECRET"
    echo -e "export API_SECRET\n\nexiting\n"
    exit
 fi
 if [ "$NIGHTSCOUT_HOST" = "" ]; then
    echo "NIGHTSCOUT_HOST environment variable is not set"
    echo -e "Make sure the two lines below are in your ~/.bash_profile as follows:\n"
-   echo "NIGHTSCOUT_HOST=https://xxxx # where xxxx is your hased Nightscout url"
+   echo "NIGHTSCOUT_HOST=https://xxxx # where xxxx is your hashed Nightscout url"
    echo -e "export NIGHTSCOUT_HOST\n\nexiting\n"
    exit
 fi

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -47,7 +47,7 @@ cat ./entry.json
 #        scaling unfiltered directly, i.e., use a variable, as there values
 #        should be passed to NS unaltered. This will become more important
 #        when we also send it a cal record...)
-calSlope=850
+calSlope=950
 scaled=$(cat ./entry.json | jq -M $glucoseType)
 scaled=$(($scaled / $calSlope))
 tmp=$(mktemp)

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -158,6 +158,7 @@ if [ -z $lastGlucose -o $(bc <<< "$lastGlucose < 40") -eq 1 ] ; then
 else
   dg=$(bc <<< "$glucose - $lastGlucose")
 fi
+echo "lastGlucose=$lastGlucose, dg=$dg"
 
 # begin try out averaging last two entries ...
 da=$dg

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -11,11 +11,13 @@ CALIBRATION_STORAGE="calibration.json"
 
 # remove old calibration storage when sensor change occurs
 # calibrate after 15 minutes of sensor change time entered in NS
-curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "15 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
-if [ $? == 0 ]; then
-  echo "sensor change - removing calibration"
-  rm $CALIBRATION_STORAGE
-fi
+# disable this feature for now. It isn't recreating the calibration file after sensor insert and BG check
+#
+#curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "15 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
+#if [ $? == 0 ]; then
+#  echo "sensor change - removing calibration"
+#  rm $CALIBRATION_STORAGE
+#fi
 
 if [ -e "./entry.json" ] ; then
   lastGlucose=$(cat ./entry.json | jq -M $glucoseType)

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -17,7 +17,7 @@ e -d "120 minutes ago" -Iminutes -u)" 2>/dev/null  > $NS_RAW
 createdAt=$(jq ".[0].created_at" $NS_RAW)
 if [[ $createdAt == *"Z"* ]]; then
   UTC=" -u "
-  echo "NS s using UTC --Using UTC=$UTC"       
+  echo "NS is using UTC --Using UTC=$UTC"       
 else
   UTC=""
   echo "NS is not using UTC --Using UTC=$UTC"       
@@ -106,13 +106,14 @@ if [ -z $meterbg ]; then
   fi
   echo "meterbg from nightscout: $meterbg"
 
-  if [ "$meterBG" != "null" -a "$meterBG" != "" ]; then
+  if [ "$meterbg" != "null" -a "$meterbg" != "" ]; then
     if [ $(bc <<< "$meterbg < 400") -eq 1  -a $(bc <<< "$meterbg > 40") -eq 1 ]; then
       echo "$unfiltered,$meterbg,$datetime,$meterbgid" >> $CAL_INPUT
       ./calc-calibration.sh $CAL_INPUT $CAL_OUTPUT
     else
       echo "Invalid calibration"
     fi
+    cat $CAL_INPUT
     cat $CAL_OUTPUT
   fi
 fi
@@ -129,7 +130,7 @@ calibratedBG=$(bc -l <<< "($unfiltered - $yIntercept)/$slope")
 calibratedBG=$(bc <<< "($calibratedBG / 1)") # truncate
 echo "After calibration calibratedBG =$calibratedBG, slope=$slope, yIntercept=$yIntercept, unfiltered=$unfiltered"
 
-if [ $(bc <<< "$calibratedBG > 400") -eq 1 -o $(bc <<< "$calibratedBG < 40") -eq 1 ]; then
+if [ -z $calibratedBG -o $(bc <<< "$calibratedBG > 400") -eq 1 -o $(bc <<< "$calibratedBG < 40") -eq 1 ]; then
   echo "Glucose $calibratedBG out of range [40,400] - exiting"
   bt-device -r $id
   exit

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -20,13 +20,10 @@ CAL_OUTPUT="./calibration-linear.json"
 #  echo "sensor change - removing calibration"
 #  rm $CALIBRATION_STORAGE
 #fi
-calSlope=999
-b=16906
-m=914
+glucoseType='.[0].unfiltered'
 
 if [ -e "./entry.json" ] ; then
-  lastGlucose=$(cat ./entry.json | jq -M $glucoseType)
-  lastGlucose=$(($lastGlucose / $calSlope))
+  lastGlucose=$(cat ./entry.json | jq -M '.[0].glucose')
   
 #  lastAfter=$(date -d "5 minutes ago" -Iminutes)
 #  lastPostStr="'.[0] | select(.dateString > \"$lastAfter\") | .glucose'"
@@ -47,14 +44,83 @@ DEBUG=smp,transmitter,bluetooth-manager timeout 360s node logger $transmitter
 echo
 echo "after xdrip-js bg record below ..."
 cat ./entry.json
+glucose=$(cat ./entry.json | jq -M '.[0].glucose')
 
-# re-scale unfiltered from /1000 to /$calSlope
+if [ -z "${glucose}" ] ; then
+  echo "Invalid response from g5 transmitter"
+  ls -al ./entry.json
+  rm ./entry.json
+fi
 
-scaled=$(cat ./entry.json | jq -M $glucoseType)
-scaled=$(($scaled / $calSlope))
-tmp=$(mktemp)
-glucose=$scaled
-echo "scaled glucose=$glucose, scale=$calSlope"
+# capture raw values for use and for log to csv file 
+unfiltered=$(cat ./entry.json | jq -M '.[0].unfiltered')
+filtered=$(cat ./entry.json | jq -M '.[0].filtered')
+glucoseg5=$(cat ./entry.json | jq -M '.[0].glucose')
+datetime=$(date +"%Y-%m-%d %H:%M")
+
+# begin calibration logic - look for calibration from NS, use existing calibration or none
+ns_url="${NIGHTSCOUT_HOST}"
+METERBG_NS_RAW="meterbg_ns_raw.json"
+
+rm $METERBG_NS_RAW # clear any old meterbg curl responses
+
+# look for a bg check from pumphistory (direct from meter->openaps):
+meterbgafter=$(date -d "7 minutes ago" -Iminutes)
+meterjqstr="'.[] | select(._type == \"BGReceived\") | select(.timestamp > \"$meterbgafter\") | .amount'"
+meterbg=$(bash -c "jq $meterjqstr ~/myopenaps/monitor/pumphistory-merged.json")
+# TBD: meter BG from pumphistory doesn't support mmol yet - has no units...
+echo "meterbg from pumphistory: $meterbg"
+
+if [ -z $meterbg ]; then
+  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+  createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
+
+  if [[ $createdAt == *"Z"* ]]; then
+     echo "meterbg within 7 minutes using UTC time comparison."       
+  else   
+    if [ "$createdAt" != "null" -a "$createdAt" != "" ]; then
+      curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+      echo "meterbg within 7 minutes using non-UTC time comparison."
+    fi
+  fi
+    
+  meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
+  meterbg=`jq -M '.[0] .glucose' $METERBG_NS_RAW`
+  meterbg="${meterbg%\"}"
+  meterbg="${meterbg#\"}"
+  if [ "$meterbgunits" == "mmol" ]; then
+    meterbg=$(bc <<< "($meterbg *18)/1")
+  fi
+  echo "meterbg from nightscout: $meterbg"
+
+  if [ $(bc <<< "$meterbg < 400") -eq 1  -a $(bc <<< "$meterbg > 40") -eq 1 ]; then
+    echo "$unfiltered,$meterbg,$datetime" >> $CAL_INPUT
+    ./calc-calibration.sh $CAL_INPUT $CAL_OUTPUT
+  else
+    echo "Invalid calibration"
+  fi
+  cat $CAL_OUTPUT
+fi
+
+if [ -e $CAL_OUTPUT ]; then
+  slope=`jq -M '.[0] .slope' calibration-linear.json` 
+  yIntercept=`jq -M '.[0] .yIntercept' calibration-linear.json` 
+else
+  slope=1000
+  yIntercept=0
+fi
+
+calibratedBG=$(bc -l <<< "($unfiltered-$yIntercept)/$slope")
+calibratedBG=$(bc <<< "($calibratedBG/1)") # truncate
+echo "After calibration calibratedBG =$calibratedBG, slope=$slope, yIntercept=$yIntercept, unfiltered=$unfiltered"
+
+if [ $(bc <<< "$calibratedBG > 400") -eq 1 -o $(bc <<< "$calibratedBG < 40") -eq 1 ]; then
+  echo "Glucose $calibratedBG out of range [40,400] - exiting"
+  bt-device -r $id
+  exit
+fi
+
+glucose=$calibratedBG
 
 if [ -z "${glucose}" ] ; then
   echo "Invalid response from g5 transmitter"
@@ -74,100 +140,13 @@ else
     da=$(bc <<< "0 - $da")
   fi
   if [ "$da" -lt "45" -a "$da" -gt "15" ]; then
-     echo "Before Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=$glucose"
-     glucose=$(bc <<< "($glucose + $lastGlucose)/2")
-     dg=$(bc <<< "$glucose - $lastGlucose")
-     echo "After average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=${glucose}"
+   echo "Before Average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=$glucose"
+   glucose=$(bc <<< "($glucose + $lastGlucose)/2")
+   dg=$(bc <<< "$glucose - $lastGlucose")
+   echo "After average last 2 entries - lastGlucose=$lastGlucose, dg=$dg, glucose=${glucose}"
   fi
   # end average last two entries if noise  code
 
-  # log to csv file for research g5 outputs
-  unfiltered=$(cat ./entry.json | jq -M '.[0].unfiltered')
-  filtered=$(cat ./entry.json | jq -M '.[0].filtered')
-  glucoseg5=$(cat ./entry.json | jq -M '.[0].glucose')
-  datetime=$(date +"%Y-%m-%d %H:%M")
-  # end log to csv file logic for g5 outputs
-
-  # begin calibration logic - look for calibration from NS, use existing calibration or none
-  calibration=0
-  ns_url="${NIGHTSCOUT_HOST}"
-  METERBG_NS_RAW="meterbg_ns_raw.json"
-
-  rm $METERBG_NS_RAW # clear any old meterbg curl responses
-
-  # look for a bg check from pumphistory (direct from meter->openaps):
-  meterbgafter=$(date -d "7 minutes ago" -Iminutes)
-  meterjqstr="'.[] | select(._type == \"BGReceived\") | select(.timestamp > \"$meterbgafter\") | .amount'"
-  meterbg=$(bash -c "jq $meterjqstr ~/myopenaps/monitor/pumphistory-merged.json")
-  # TBD: meter BG from pumphistory doesn't support mmol yet - has no units...
-  echo "meterbg from pumphistory: $meterbg"
-
-  if [ -z $meterbg ]; then
-    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-    createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
-
-    if [[ $createdAt == *"Z"* ]]; then
-       echo "meterbg within 7 minutes using UTC time comparison."       
-    else   
-      if [ "$createdAt" != "null" -a "$createdAt" != "" ]; then
-        curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
-        echo "meterbg within 7 minutes using non-UTC time comparison."
-      fi
-    fi
-    
-    meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
-    meterbg=`jq -M '.[0] .glucose' $METERBG_NS_RAW`
-    meterbg="${meterbg%\"}"
-    meterbg="${meterbg#\"}"
-    if [ "$meterbgunits" == "mmol" ]; then
-      meterbg=$(bc <<< "($meterbg *18)/1")
-    fi
-    echo "meterbg from nightscout: $meterbg"
-
-if [ $(bc <<< "$meterbg < 400") -eq 1  -a $(bc <<< "$meterbg > 40") -eq 1 ]; then
-#      calibrationBg=$meterbg
-#      calibration="$(bc <<< "$calibrationBg - $glucose")"
-#      echo "calibration=$calibration, meterbg=$meterbg, calibrationBg=$calibrationBg, glucose=$glucose"
-#      if [ $(bc <<< "$calibration < 60") -eq 1 -a $(bc <<< "$calibration > -150") -eq 1 ]; then
-        # another safety check, but this is a good calibration
-#        if [ -e $CALIBRATION_STORAGE ]; then
-#          tmp=$(mktemp)
-#          jq ".[0].calibration = $calibration" $CALIBRATION_STORAGE > "$tmp" && mv "$tmp" $CALIBRATION_STORAGE 
-#        else
-#          echo "[{\"calibration\":$calibration}]" > $CALIBRATION_STORAGE
-#        fi
-        #Begin log calibrations for 1pt 2pt and regressive calibration calculations
-        echo "$unfiltered,$meterbg,$datetime" >> $CAL_INPUT
-        ./calc-calibration.sh $CAL_INPUT $CAL_OUTPUT
-
-#        cp $METERBG_NS_RAW meterbg-ns-backup.json
-      else
-        echo "Invalid calibration"
-      fi
-      cat $CAL_OUTPUT
-    fi
-  fi
-
-  if [ -e $CAL_OUTPUT ]; then
-#    calibration=$(cat $CALIBRATION_STORAGE | jq -M '.[0] | .calibration')
-    slope=`jq -M '.[0] .slope' calibration-linear.json` 
-    yIntercept=`jq -M '.[0] .yIntercept' calibration-linear.json` 
-  else
-    slope=1000
-    yIntercept=0
-#    echo "No valid calibration yet - exiting"
-#    bt-device -r $id
-#    exit
-  fi
-  calibratedglucose=$(bc <<< "$glucose + $calibration")
-  echo "After calibration calibratedglucose =$calibratedglucose"
-
-
-  if [ $(bc <<< "$calibratedglucose > 400") -eq 1 -o $(bc <<< "$calibratedglucose < 40") -eq 1 ]; then
-    echo "Glucose $calibratedglucose out of range [40,400] - exiting"
-    bt-device -r $id
-    exit
-  fi
 
   if [ $(bc <<< "$dg > 50") -eq 1 -o $(bc <<< "$dg < -50") -eq 1 ]; then
     echo "Change $dg out of range [50,-50] - exiting"
@@ -178,10 +157,10 @@ if [ $(bc <<< "$meterbg < 400") -eq 1  -a $(bc <<< "$meterbg > 40") -eq 1 ]; the
    cp entry.json entry-before-calibration.json
 
    tmp=$(mktemp)
-   jq ".[0].glucose = $calibratedglucose" entry.json > "$tmp" && mv "$tmp" entry.json
+   jq ".[0].glucose = $calibratedBG" entry.json > "$tmp" && mv "$tmp" entry.json
 
    tmp=$(mktemp)
-   jq ".[0].sgv = $calibratedglucose" entry.json > "$tmp" && mv "$tmp" entry.json
+   jq ".[0].sgv = $calibratedBG" entry.json > "$tmp" && mv "$tmp" entry.json
 
    tmp=$(mktemp)
    jq ".[0].device = \"${transmitter}\"" entry.json > "$tmp" && mv "$tmp" entry.json
@@ -235,13 +214,11 @@ if [ $(bc <<< "$meterbg < 400") -eq 1  -a $(bc <<< "$meterbg > 40") -eq 1 ]; the
 
 
   if [ ! -f "/var/log/openaps/g5.csv" ]; then
-    echo "datetime,unfiltered,filtered,glucoseg5,glucose,calibratedglucose,slope,direction,calibration,calibrationBg,predictedBg,slope,yIntercept" > /var/log/openaps/g5.csv
+    echo "datetime,unfiltered,filtered,glucoseg5,glucose,direction,calibratedBG,slope,yIntercept" > /var/log/openaps/g5.csv
   fi
 
 
-  predicted=$(bc -l <<< "($unfiltered-$yIntercept)/$slope")
-  predicted=$(bc <<< "($predicted/1)") # truncate
-  echo "${datetime},${unfiltered},${filtered},${glucoseg5},${glucose},${calibratedglucose},${calSlope},${direction},${calibration},${calibrationBg},${predicted},${slope},${yIntercept}" >> /var/log/openaps/g5.csv
+  echo "${datetime},${unfiltered},${filtered},${glucoseg5},${glucose},${direction},${calibratedBG},${slope},${yIntercept}" >> /var/log/openaps/g5.csv
 
   echo "Posting glucose record to xdripAPS"
   ./post-xdripAPS.sh ./entry-xdrip.json

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -80,13 +80,7 @@ else
   # remove old calibration storage when sensor change occurs
   # calibrate after 15 minutes of sensor change time entered in NS
   curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -u -d "15 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
-  if [ $? == 0 ]; thenEric,
-
-I got sick over the weekend. Thought it may be better by this morning but it got worse overnight. 
-Sorry I’m going to miss SLT and the mentee dinner.
-
-Thanks,
-
+  if [ $? == 0 ]; then
     rm $CALIBRATION_STORAGE
   fi
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -243,7 +243,7 @@ fi
 # end average last two entries if noise  code
 
 
-if [ $(bc <<< "$dg > $maxDelta") -eq 1 -o $(bc <<< "$dg < (0 - $maxDelta") -eq 1 ]; then
+if [ $(bc <<< "$dg > $maxDelta)" -eq 1 -o $(bc <<< "$dg < (0 - $maxDelta)" -eq 1 ]; then
   echo "Change $dg out of range [$maxDelta,-${maxDelta}] - exiting"
   bt-device -r $id
   exit

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -89,13 +89,13 @@ else
     curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
     createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
 
-    if [[ $createdAt != *"Z"* ]]; then
+    if [[ $createdAt == *"Z"* ]]; then
+       echo "meterbg within 7 minutes using UTC time comparison."       
+    elif   
       if [ "$createdAt" != "NULL" -a "$createdAt" != "" ]; then
         curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
         echo "meterbg within 7 minutes using non-UTC time comparison."
       fi
-    elif [[ $createdAt == *"Z" ]];then
-        echo "meterbg within 7 minutes using UTC time comparison."       
     fi
     
     meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -8,6 +8,8 @@ echo "Starting xdrip-get-entries.sh"
 date
 
 # Check required environment variables
+export API_SECRET
+export NIGHTSCOUT_HOST
 if [ "$API_SECRET" = "" ]; then
    echo "API_SECRET environment variable is not set"
    echo -e "Make sure the two lines below are in your ~/.bash_profile as follows:\n"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -118,8 +118,8 @@ else
   yIntercept=0
 fi
 
-calibratedBG=$(bc -l <<< "($unfiltered-$yIntercept)/$slope")
-calibratedBG=$(bc <<< "($calibratedBG/1)") # truncate
+calibratedBG=$(bc -l <<< "($unfiltered - $yIntercept)/$slope")
+calibratedBG=$(bc <<< "($calibratedBG / 1)") # truncate
 echo "After calibration calibratedBG =$calibratedBG, slope=$slope, yIntercept=$yIntercept, unfiltered=$unfiltered"
 
 if [ $(bc <<< "$calibratedBG > 400") -eq 1 -o $(bc <<< "$calibratedBG < 40") -eq 1 ]; then

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -22,7 +22,7 @@ transmitter=$1
 
 id2=$(echo "${transmitter: -2}")
 id="Dexcom${id2}"
-echo "Removing existing Dexcom bluetooth connection = ${id}"'.[0].unfiltered'
+echo "Removing existing Dexcom bluetooth connection = ${id}"
 bt-device -r $id
 
 echo "Calling xdrip-js ... node logger $transmitter"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -84,7 +84,19 @@ else
   echo "meterbg from pumphistory: $meterbg"
 
   if [ -z $meterbg ]; then
-    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+    curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "100 hours ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+    createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
+    echo createdAt=${createdAt}
+
+    if [[ $createdAt == *"Z"* ]]; then
+      echo "NS is UTC"
+      curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+    else
+      echo "NS is not UTC"
+      curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+    fi
+    
+#curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "7 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
 
     meterbgunits=$(cat $METERBG_NS_RAW | jq -M '.[0] | .units')
     meterbg=`jq -M '.[0] .glucose' $METERBG_NS_RAW`
@@ -112,7 +124,43 @@ else
         cp $METERBG_NS_RAW meterbg-ns-backup.json
       fi
     fi
-  fi
+  ficurl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "100 hours ago" -
+Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+
+
+createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
+echo createdAt=${createdAt}
+
+if [[ $createdAt == *"Z"* ]]; then
+  echo "UTC"
+  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "1 hours ago" -
+Ihours)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+
+else
+  echo "Not UTC"
+  curl -m 30 "${ns_url}/api/v1/treatments.jsoncurl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "100 hours ago" -
+Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+
+
+createdAt=$(jq ".[0].created_at" $METERBG_NS_RAW)
+echo createdAt=${createdAt}
+
+if [[ $createdAt == *"Z"* ]]; then
+  echo "UTC"
+  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "1 hours ago" -
+Ihours)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+
+else
+  echo "Not UTC"
+  curl -m 30 "${ns_url}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "1 hours ago" -
+Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+
+fi
+?find\[created_at\]\[\$gte\]=$(date -d "1 hours ago" -
+Ihours -u)&find\[eventType\]\[\$regex\]=Check" 2>/dev/null > $METERBG_NS_RAW
+
+fi
+
 
   if [ -e $CALIBRATION_STORAGE ]; then
     calibration=$(cat $CALIBRATION_STORAGE | jq -M '.[0] | .calibration')

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -11,7 +11,7 @@ CALIBRATION_STORAGE="calibration.json"
 
 # remove old calibration storage when sensor change occurs
 # calibrate after 15 minutes of sensor change time entered in NS
-curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "15 minutes ago" -Iminutes)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
+curl -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "15 minutes ago" -Iminutes -u)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
 if [ $? == 0 ]; then
   echo "sensor change - removing calibration"
   rm $CALIBRATION_STORAGE


### PR DESCRIPTION
Noise is currently calculated based off the last 8 unfiltered values from the sensor. It uses a method that evaluates the "jumpiness" of the line made by the last 8 points. The closer to 0 is better. 1 is the worst theoretical noise level. Then this value is converted to Nightscout and Openaps's way of interpreting and dealing with noise as follows:
```
noise=$(./calc-noise.sh)
noiseSend=0 # unknown
if [ $(bc -l <<< "$noise < 0.5") -eq 1 ]; then
  noiseSend=1  # Clean
elif [ $(bc -l <<< "$noise < 0.6") -eq 1 ]; then
  noiseSend=2  # Light
elif [ $(bc -l <<< "$noise < 0.75") -eq 1 ]; then
  noiseSend=3  # Medium
elif [ $(bc -l <<< "$noise >= 0.75") -eq 1 ]; then
  noiseSend=4  # Heavy
fi
```
